### PR TITLE
  Allow donation address to be updated

### DIFF
--- a/src/api/DonorResource.ts
+++ b/src/api/DonorResource.ts
@@ -1,0 +1,28 @@
+import { Address } from '@/view_models/Address';
+import axios, { AxiosResponse } from 'axios';
+
+interface DonorResource {
+	putEndpoint: string,
+	put: ( data: Address ) => Promise<Address>
+}
+
+export default class implements DonorResource {
+
+	putEndpoint: string;
+
+	constructor( putEndpoint: string ) {
+		this.putEndpoint = putEndpoint;
+	}
+
+	put( data: Address ): Promise<Address> {
+		return axios.put(
+			this.putEndpoint,
+			data,
+			{ headers: { 'Content-Type': 'application/json' } }
+		).then( ( response: AxiosResponse<Address> ) => {
+			return Promise.resolve( response.data );
+		} ).catch( ( error: any ) => {
+			return Promise.reject( error.response.data.errors[ 0 ] );
+		} );
+	}
+}

--- a/src/components/pages/DonationConfirmation.vue
+++ b/src/components/pages/DonationConfirmation.vue
@@ -17,7 +17,7 @@
 					v-on:show-comment-modal="showCommentModal()"
 				/>
 			</div>
-			<div class="column is-half pt-0 pb-0">
+			<div class="column is-half pt-0 pb-0" v-if="!donation.isExported">
 				<address-known
 					v-if="showAddress"
 					v-on:show-address-modal="showAddressModal()"
@@ -29,6 +29,9 @@
 				/>
 				<address-anonymous v-else v-on:show-address-modal="showAddressModal()"/>
 
+			</div>
+			<div class="column is-half pt-0 pb-0" v-else>
+				<donation-exported :address-type="currentAddressType"/>
 			</div>
 			<div class="column is-half pt-0 pb-0" id="become-a-member" ref="becomeAMember">
 				<membership-info
@@ -97,10 +100,12 @@ import AddressAnonymous from '@/components/pages/donation_confirmation/AddressAn
 import Survey from '@/components/pages/donation_confirmation/Survey.vue';
 import DonationCommentPopUp from '@/components/DonationCommentPopUp.vue';
 import ChevronDownIcon from '@/components/shared/icons/ChevronDown.vue';
+import DonationExported from '@/components/pages/donation_confirmation/DonationExported.vue';
 
 export default Vue.extend( {
 	name: 'DonationConfirmation',
 	components: {
+		DonationExported,
 		ChevronDownIcon,
 		Survey,
 		SuccessMessageBankTransfer,

--- a/src/components/pages/DonationConfirmation.vue
+++ b/src/components/pages/DonationConfirmation.vue
@@ -28,9 +28,8 @@
 					:salutations="salutations"
 				/>
 				<address-anonymous v-else v-on:show-address-modal="showAddressModal()"/>
-
 			</div>
-			<div class="column is-half pt-0 pb-0" v-else>
+			<div class="column is-half pt-0 pb-0" v-else-if="addressType === 'person' || addressType === 'firma'">
 				<donation-exported :address-type="currentAddressType"/>
 			</div>
 			<div class="column is-half pt-0 pb-0" id="become-a-member" ref="becomeAMember">

--- a/src/components/pages/DonationConfirmation.vue
+++ b/src/components/pages/DonationConfirmation.vue
@@ -2,7 +2,7 @@
 	<div class="donation-confirmation">
 		<a class="mobile-call-to-action is-primary button" href="#membership-application-url"
 			v-on:click="scrollToCallToAction"
-			v-if="isMobileCallToActionButtonVisible">
+			v-if="isMobileCallToActionButtonVisible && !isAddressModalOpen">
 			Jetzt Fördermitglied werden
 			<chevron-down-icon/>
 		</a>

--- a/src/components/pages/DonationConfirmation.vue
+++ b/src/components/pages/DonationConfirmation.vue
@@ -47,7 +47,7 @@
 				:countries="countries"
 				:salutations="salutations"
 				:donation="donation"
-				:updateDonorUrl="updateDonorUrl"
+				:donorResource="donorResource"
 				:validate-address-url="validateAddressUrl"
 				:validate-email-url="validateEmailUrl"
 				:address-validation-patterns="addressValidationPatterns"
@@ -101,6 +101,7 @@ import Survey from '@/components/pages/donation_confirmation/Survey.vue';
 import DonationCommentPopUp from '@/components/DonationCommentPopUp.vue';
 import ChevronDownIcon from '@/components/shared/icons/ChevronDown.vue';
 import DonationExported from '@/components/pages/donation_confirmation/DonationExported.vue';
+import DonorResource from '@/api/DonorResource';
 
 export default Vue.extend( {
 	name: 'DonationConfirmation',
@@ -133,7 +134,6 @@ export default Vue.extend( {
 		donation: Object as () => Donation,
 		address: Object,
 		addressType: String,
-		updateDonorUrl: String,
 		cancelMembershipUrl: String,
 		validateAddressUrl: String,
 		validateEmailUrl: String,
@@ -142,6 +142,7 @@ export default Vue.extend( {
 		countries: Array as () => Array<Country>,
 		salutations: Array as () => Array<Salutation>,
 		addressValidationPatterns: Object as () => AddressValidation,
+		donorResource: Object as () => DonorResource,
 	},
 	methods: {
 		showAddressModal: function () {

--- a/src/components/pages/donation_confirmation/AddressKnown.vue
+++ b/src/components/pages/donation_confirmation/AddressKnown.vue
@@ -26,9 +26,9 @@
 			} )"></p>
 		</div>
 		<div class="payment-email has-margin-bottom-18" v-html="$t( 'donation_confirmation_email', { email: this.$props.address.email } )"></div>
-		<!--div>{{ $t( 'donation_confirmation_address_update' ) }}
+		<div>{{ $t( 'donation_confirmation_address_update' ) }}
 			<a href="#" id="update-address-link" @click="$emit( 'show-address-modal' )">{{ $t( 'donation_confirmation_address_update_link' ) }}</a>
-		</div-->
+		</div>
 	</div>
 </template>
 

--- a/src/components/pages/donation_confirmation/AddressKnown.vue
+++ b/src/components/pages/donation_confirmation/AddressKnown.vue
@@ -12,15 +12,15 @@
 			<p v-if="addressType === 'person'" v-html="$t( 'donation_confirmation_address_person', {
 				salutation: salutation,
 				fullName: address.fullName,
-				streetAddress: address.streetAddress,
-				postalCode: address.postalCode,
+				streetAddress: address.street,
+				postalCode: address.postcode,
 				city: address.city,
 				country: country
 			} )"></p>
 			<p v-else v-html="$t( 'donation_confirmation_address_company', {
 				fullName: address.fullName,
-				streetAddress: address.streetAddress,
-				postalCode: address.postalCode,
+				streetAddress: address.street,
+				postalCode: address.postcode,
 				city: address.city,
 				country: country
 			} )"></p>
@@ -38,6 +38,7 @@ import { Donation } from '@/view_models/Donation';
 import { Country } from '@/view_models/Country';
 import SuccessIcon from '@/components/shared/icons/SuccessIcon.vue';
 import { TranslateResult } from 'vue-i18n';
+import { Address } from '@/view_models/Address';
 import { Salutation } from '@/view_models/Salutation';
 
 export default Vue.extend( {
@@ -47,12 +48,12 @@ export default Vue.extend( {
 	},
 	data: function () {
 		return {
-			countryCode: this.$props.address.countryCode,
+			countryCode: this.$props.address.country,
 		};
 	},
 	props: {
 		donation: Object as () => Donation,
-		address: Object,
+		address: Object as () => Address,
 		addressType: String,
 		countries: Array as () => Array<Country>,
 		salutations: Array as () => Array<Salutation>,

--- a/src/components/pages/donation_confirmation/AddressTypeFull.vue
+++ b/src/components/pages/donation_confirmation/AddressTypeFull.vue
@@ -3,12 +3,14 @@
 		<legend class="subtitle">{{ $t( 'donation_form_section_address_header_type' ) }}</legend>
 		<div class="radio-container">
 			<b-radio
+					id="address-type-person"
 					name="addressTypeInternal"
 					v-model="addressType"
 					native-value="person"
 			>{{ $t( 'donation_form_addresstype_option_private' ) }}
 			</b-radio>
 			<b-radio
+					id="address-type-company"
 					name="addressTypeInternal"
 					v-model="addressType"
 					native-value="company"
@@ -30,7 +32,7 @@ export default defineComponent( {
 	},
 	setup( props, { emit } ) {
 
-		const addressType = ref<string>( props.initialAddressType ? props.initialAddressType : 'unset' );
+		const addressType = ref<string>( props.initialAddressType ?? 'unset' );
 
 		watch( addressType, newAddressType => {
 			switch ( newAddressType ) {

--- a/src/components/pages/donation_confirmation/DonationExported.vue
+++ b/src/components/pages/donation_confirmation/DonationExported.vue
@@ -1,0 +1,35 @@
+<template>
+	<div class="donation-confirmation-card exported-donation has-background-bright mb-4">
+		<h2 class="icon-title is-size-5 has-margin-bottom-18">
+			<warning-icon/>
+			{{ addressType === 'person' ?
+				$t( 'donation_confirmation_exported_title_person' ) :
+				$t( 'donation_confirmation_exported_title_company' )
+			}}
+		</h2>
+		<p>
+			{{ addressType === 'person' ?
+				$t( 'donation_confirmation_exported_content_person' ) :
+				$t( 'donation_confirmation_exported_content_company' )
+			}}
+		</p>
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import WarningIcon from '@/components/shared/icons/WarningIcon.vue';
+
+export default Vue.extend( {
+	name: 'DonationExported',
+	components: { WarningIcon },
+	props: {
+		addressType: String,
+	},
+} );
+
+</script>
+
+<style lang="scss">
+
+</style>

--- a/src/components/pages/donation_confirmation/DonationExported.vue
+++ b/src/components/pages/donation_confirmation/DonationExported.vue
@@ -1,17 +1,10 @@
 <template>
 	<div class="donation-confirmation-card exported-donation has-background-bright mb-4">
 		<h2 class="icon-title is-size-5 has-margin-bottom-18">
-			<warning-icon/>
-			{{ addressType === 'person' ?
-				$t( 'donation_confirmation_exported_title_person' ) :
-				$t( 'donation_confirmation_exported_title_company' )
-			}}
+			<warning-icon/> {{ $t( 'donation_confirmation_exported_title' ) }}
 		</h2>
 		<p>
-			{{ addressType === 'person' ?
-				$t( 'donation_confirmation_exported_content_person' ) :
-				$t( 'donation_confirmation_exported_content_company' )
-			}}
+			{{ $t( 'donation_confirmation_exported_content' ) }}
 		</p>
 	</div>
 </template>

--- a/src/components/pages/donation_form/subpages/AddressPage.vue
+++ b/src/components/pages/donation_form/subpages/AddressPage.vue
@@ -229,7 +229,10 @@ export default Vue.extend( {
 			.scrollIntoView( { behavior: 'smooth', block: 'center', inline: 'nearest' } );
 		const submit = () => {
 			const validationCalls = [
-				store.dispatch( action( NS_ADDRESS, validateAddressType ), store.state.address.addressType ),
+				store.dispatch( action( NS_ADDRESS, validateAddressType ), {
+					type: store.state.address.addressType,
+					disallowed: [ AddressTypeModel.UNSET ],
+				} ),
 				store.dispatch( action( NS_ADDRESS, validateAddress ), props.validateAddressUrl ),
 				store.dispatch( action( NS_ADDRESS, validateEmail ), props.validateEmailUrl ),
 			];

--- a/src/components/shared/Email.vue
+++ b/src/components/shared/Email.vue
@@ -13,7 +13,7 @@
 		<span v-if="suggestedProvider" @click="onSuggestionClicked(suggestedProvider)" class="help is-clickable">
 			{{ $t( 'donation_form_email_suggestion' ) }} <strong>{{ suggestedProvider }}</strong>?
 		</span>
-		<span v-if="showError" class="help is-danger">{{ $t( 'donation_form_email_error' ) }}</span>
+		<span v-if="showError" class="help is-danger error-email">{{ $t( 'donation_form_email_error' ) }}</span>
 		<ValueEqualsPlaceholderWarning
 			:value="formData.email.value"
 			:placeholder="$t( 'donation_form_email_placeholder' )"

--- a/src/components/shared/Name.vue
+++ b/src/components/shared/Name.vue
@@ -13,7 +13,7 @@
 					{{ salutation.label }}
 				</b-radio>
 			</div>
-			<span v-if="showError.salutation" class="help is-danger"> {{ $t( 'donation_form_salutation_error' ) }}</span>
+			<span v-if="showError.salutation" class="help is-danger error-salutation"> {{ $t( 'donation_form_salutation_error' ) }}</span>
 		</fieldset>
 		<div class="form-input">
 			<label for="title" class="subtitle">{{ $t( 'donation_form_academic_title_label' ) }}</label>
@@ -43,7 +43,7 @@
 						@blur="$emit('field-changed', 'firstName')">
 				</b-input>
 			</b-field>
-			<span v-if="showError.firstName" class="help is-danger">{{ $t( 'donation_form_firstname_error' ) }}</span>
+			<span v-if="showError.firstName" class="help is-danger error-first-name">{{ $t( 'donation_form_firstname_error' ) }}</span>
 		</div>
 		<div v-bind:class="['form-input', { 'is-invalid': showError.lastName }]">
 			<label for="last-name" class="subtitle">{{ $t( 'donation_form_lastname_label' ) }}</label>
@@ -56,7 +56,7 @@
 						@blur="$emit('field-changed', 'lastName')">
 				</b-input>
 			</b-field>
-			<span v-if="showError.lastName" class="help is-danger">{{ $t( 'donation_form_lastname_error' ) }}</span>
+			<span v-if="showError.lastName" class="help is-danger error-last-name">{{ $t( 'donation_form_lastname_error' ) }}</span>
 			<ValueEqualsPlaceholderWarning
 				:value="formData.lastName.value"
 				:placeholder="$t( 'donation_form_lastname_placeholder_check' )"
@@ -75,7 +75,7 @@
 					@blur="$emit('field-changed', 'companyName')">
 			</b-input>
 		</b-field>
-		<span v-if="showError.companyName" class="help is-danger">{{ $t( 'donation_form_companyname_error' )  }}</span>
+		<span v-if="showError.companyName" class="help is-danger  error-company-name">{{ $t( 'donation_form_companyname_error' )  }}</span>
 	</div>
 </div>
 </template>

--- a/src/components/shared/Postal.vue
+++ b/src/components/shared/Postal.vue
@@ -11,7 +11,7 @@
 					@blur="$emit('field-changed', 'street'); displayStreetWarning()">
 			</b-input>
 		</b-field>
-		<span v-if="showError.street" class="help is-danger">{{ $t('donation_form_street_error') }}</span>
+		<span v-if="showError.street" class="help is-danger error-street">{{ $t('donation_form_street_error') }}</span>
 		<span v-if="showWarning" class="help">{{ $t('donation_form_street_number_warning') }}</span>
 		<ValueEqualsPlaceholderWarning
 			:value="formData.street.value"
@@ -30,7 +30,7 @@
 					@blur="$emit('field-changed', 'postcode')">
 			</b-input>
 		</b-field>
-		<span v-if="showError.postcode" class="help is-danger">{{ $t('donation_form_zip_error') }}</span>
+		<span v-if="showError.postcode" class="help is-danger error-postcode">{{ $t('donation_form_zip_error') }}</span>
 		<ValueEqualsPlaceholderWarning
 			:value="formData.postcode.value"
 			:placeholder="$t( 'donation_form_zip_placeholder' )"
@@ -41,7 +41,6 @@
 		<label for="city" class="subtitle">{{ $t( 'donation_form_city_label' ) }}</label>
 		<b-field :type="{ 'is-danger': showError.city }">
 			<AutocompleteCity
-				id="city"
 				:city="formData.city"
 				:example-placeholder="'donation_form_city_placeholder'"
 				:show-error="showError.city"
@@ -49,7 +48,7 @@
 				v-on:field-changed="$emit('field-changed', 'city')"
 			/>
 		</b-field>
-		<span v-if="showError.city" class="help is-danger">{{ $t('donation_form_city_error') }}</span>
+		<span v-if="showError.city" class="help is-danger error-city">{{ $t('donation_form_city_error') }}</span>
 		<ValueEqualsPlaceholderWarning
 			:value="formData.city.value"
 			:placeholder="$t( 'donation_form_city_placeholder' )"
@@ -76,7 +75,7 @@
 				<span slot="group"><hr></span>
 			</b-autocomplete>
 		</b-field>
-		<span v-if="showError.country" class="help is-danger">{{ $t('donation_form_country_error') }}</span>
+		<span v-if="showError.country" class="help is-danger error-country">{{ $t('donation_form_country_error') }}</span>
 	</div>
 </div>
 </template>

--- a/src/pages/donation_confirmation.ts
+++ b/src/pages/donation_confirmation.ts
@@ -18,7 +18,7 @@ import { trackGoal } from '@/tracking';
 import { action } from '@/store/util';
 import { NS_ADDRESS } from '@/store/namespaces';
 import { initializeAddress } from '@/store/address/actionTypes';
-import { addressTypeFromName, AddressTypes } from '@/view_models/AddressTypeModel';
+import { addressTypeFromName } from '@/view_models/AddressTypeModel';
 
 const PAGE_IDENTIFIER = 'donation-confirmation',
 	IS_FULLWIDTH_PAGE = true,

--- a/src/pages/donation_confirmation.ts
+++ b/src/pages/donation_confirmation.ts
@@ -19,6 +19,7 @@ import { action } from '@/store/util';
 import { NS_ADDRESS } from '@/store/namespaces';
 import { initializeAddress } from '@/store/address/actionTypes';
 import { addressTypeFromName } from '@/view_models/AddressTypeModel';
+import { Address } from '@/view_models/Address';
 
 const PAGE_IDENTIFIER = 'donation-confirmation',
 	IS_FULLWIDTH_PAGE = true,
@@ -33,7 +34,7 @@ interface DonationConfirmationModel {
 	urls: { [ key: string ]: string },
 	countries: Array<Country>,
 	donation: Donation,
-	address: any,
+	address: Address,
 	addressType: String,
 	addressValidationPatterns: AddressValidation,
 	salutations: Array<Salutation>,
@@ -60,10 +61,10 @@ store.dispatch(
 			{ name: 'firstName', value: pageData.applicationVars.address.firstName ?? '' },
 			{ name: 'lastName', value: pageData.applicationVars.address.lastName ?? '' },
 			{ name: 'companyName', value: pageData.applicationVars.address.companyName ?? '' },
-			{ name: 'street', value: pageData.applicationVars.address.streetAddress ?? '' },
-			{ name: 'postcode', value: pageData.applicationVars.address.postalCode ?? '' },
+			{ name: 'street', value: pageData.applicationVars.address.street ?? '' },
+			{ name: 'postcode', value: pageData.applicationVars.address.postcode ?? '' },
 			{ name: 'city', value: pageData.applicationVars.address.city ?? '' },
-			{ name: 'country', value: pageData.applicationVars.address.countryCode ?? 'DE' },
+			{ name: 'country', value: pageData.applicationVars.address.country ?? 'DE' },
 			{ name: 'email', value: pageData.applicationVars.address.email ?? '' },
 		],
 	}

--- a/src/pages/donation_confirmation.ts
+++ b/src/pages/donation_confirmation.ts
@@ -21,6 +21,7 @@ import { initializeAddress } from '@/store/address/actionTypes';
 import { addressTypeFromName } from '@/view_models/AddressTypeModel';
 import { Address } from '@/view_models/Address';
 import DonorResource from '@/api/DonorResource';
+import { Validity } from '@/view_models/Validity';
 
 const PAGE_IDENTIFIER = 'donation-confirmation',
 	IS_FULLWIDTH_PAGE = true,
@@ -51,22 +52,23 @@ trackGoal( pageData.applicationVars.piwik.donationConfirmationGoalId );
 
 Vue.use( FeatureTogglePlugin, { activeFeatures: [ ...pageData.selectedBuckets, ...pageData.activeFeatures ] } );
 
+const address = pageData.applicationVars.address;
 store.dispatch(
 	action( NS_ADDRESS, initializeAddress ),
 	{
 		addressType: addressTypeFromName( pageData.applicationVars.addressType.toString() ),
 		newsletter: pageData.applicationVars.donation.newsletter,
 		fields: [
-			{ name: 'salutation', value: pageData.applicationVars.address.salutation ?? '' },
-			{ name: 'title', value: pageData.applicationVars.address.title ?? '' },
-			{ name: 'firstName', value: pageData.applicationVars.address.firstName ?? '' },
-			{ name: 'lastName', value: pageData.applicationVars.address.lastName ?? '' },
-			{ name: 'companyName', value: pageData.applicationVars.address.companyName ?? '' },
-			{ name: 'street', value: pageData.applicationVars.address.street ?? '' },
-			{ name: 'postcode', value: pageData.applicationVars.address.postcode ?? '' },
-			{ name: 'city', value: pageData.applicationVars.address.city ?? '' },
-			{ name: 'country', value: pageData.applicationVars.address.country ?? 'DE' },
-			{ name: 'email', value: pageData.applicationVars.address.email ?? '' },
+			{ name: 'salutation', value: address.salutation ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'title', value: address.title ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'firstName', value: address.firstName ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'lastName', value: address.lastName ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'companyName', value: address.companyName ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'street', value: address.street ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'postcode', value: address.postcode ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'city', value: address.city ?? '', validity: Validity.INCOMPLETE },
+			{ name: 'country', value: address.country ?? 'DE', validity: Validity.INCOMPLETE },
+			{ name: 'email', value: address.email ?? '', validity: Validity.INCOMPLETE },
 		],
 	}
 ).then( () => {
@@ -88,7 +90,7 @@ store.dispatch(
 			h( DonationConfirmation, {
 				props: {
 					donation: pageData.applicationVars.donation,
-					address: pageData.applicationVars.address,
+					address: address,
 					addressType: pageData.applicationVars.addressType,
 					countries: pageData.applicationVars.countries,
 					salutations: pageData.applicationVars.salutations,

--- a/src/pages/donation_confirmation.ts
+++ b/src/pages/donation_confirmation.ts
@@ -20,6 +20,7 @@ import { NS_ADDRESS } from '@/store/namespaces';
 import { initializeAddress } from '@/store/address/actionTypes';
 import { addressTypeFromName } from '@/view_models/AddressTypeModel';
 import { Address } from '@/view_models/Address';
+import DonorResource from '@/api/DonorResource';
 
 const PAGE_IDENTIFIER = 'donation-confirmation',
 	IS_FULLWIDTH_PAGE = true,
@@ -93,10 +94,10 @@ store.dispatch(
 					salutations: pageData.applicationVars.salutations,
 					validateAddressUrl: pageData.applicationVars.urls.validateAddress,
 					validateEmailUrl: pageData.applicationVars.urls.validateEmail,
-					updateDonorUrl: pageData.applicationVars.urls.updateDonor,
 					cancelDonationUrl: pageData.applicationVars.urls.cancelDonation,
 					postCommentUrl: pageData.applicationVars.urls.postComment,
 					addressValidationPatterns: pageData.applicationVars.addressValidationPatterns,
+					donorResource: new DonorResource( pageData.applicationVars.urls.updateDonor ),
 				},
 			} ),
 		] ),

--- a/src/store/address/actions.ts
+++ b/src/store/address/actions.ts
@@ -12,7 +12,13 @@ import {
 	validateAddressType,
 	validateCountry,
 } from '@/store/address/actionTypes';
-import { AddressState, CountryValidationFields, InitialAddressValues, InputField } from '@/view_models/Address';
+import {
+	AddressState,
+	AddressTypeValidationRequest,
+	CountryValidationFields,
+	InitialAddressValues,
+	InputField,
+} from '@/view_models/Address';
 import { ValidationResponse } from '@/store/ValidationResponse';
 import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
 import {
@@ -91,8 +97,8 @@ export const actions = {
 		context.commit( SET_ADDRESS_TYPE, type );
 		context.commit( SET_VALIDITY, { name: 'addressType', value: Validity.VALID } );
 	},
-	[ validateAddressType ]( context: ActionContext<AddressState, any>, type: AddressTypeModel ) {
-		if ( type === AddressTypeModel.UNSET ) {
+	[ validateAddressType ]( context: ActionContext<AddressState, any>, request: AddressTypeValidationRequest ) {
+		if ( request.disallowed.includes( request.type ) ) {
 			context.commit( SET_VALIDITY, { name: 'addressType', value: Validity.INVALID } );
 			return Promise.resolve( { status: 'ERR', messages: [] } );
 		}

--- a/src/view_models/Address.ts
+++ b/src/view_models/Address.ts
@@ -4,6 +4,21 @@ import { MembershipTypeModel } from './MembershipTypeModel';
 import { AddressRequirements } from '@/store/address/constants';
 import { FieldInitialization } from '@/view_models/FieldInitialization';
 
+export interface Address {
+    addressType: string,
+    salutation: string,
+    title: string,
+    firstName: string,
+    lastName: string,
+    fullName: string,
+    companyName: string,
+    street: string,
+    city: string,
+    postcode: string,
+    country: string,
+    email: string
+}
+
 export interface AddressValidity {
     [key: string]: boolean
 }

--- a/src/view_models/Address.ts
+++ b/src/view_models/Address.ts
@@ -122,3 +122,8 @@ export interface SubmittedAddress {
     addressData: AddressFormData,
     addressType: string
 }
+
+export interface AddressTypeValidationRequest {
+    type: AddressTypeModel,
+    disallowed: AddressTypeModel[]
+}

--- a/src/view_models/Donation.ts
+++ b/src/view_models/Donation.ts
@@ -11,4 +11,6 @@ export interface Donation {
 	paymentType: String,
 	status: String
 	updateToken: String,
+
+	isExported: Boolean,
 }

--- a/tests/data/confirmationData.ts
+++ b/tests/data/confirmationData.ts
@@ -24,6 +24,7 @@ function createConfirmationData( overrides: any ) {
 			newsletter: false,
 			paymentType: '',
 			updateToken: 'd387cebd6cc05efbd117545492cb0e99',
+			isExported: false,
 		},
 		countries: [
 			{
@@ -98,5 +99,13 @@ export const directDebitConfirmationData = createConfirmationData( {
 	donation: {
 		paymentType: 'BEZ',
 		bankTransferCode: testBankTransferCode,
+	},
+} );
+
+export const donationExportedConfirmationData = createConfirmationData( {
+	donation: {
+		paymentType: 'PPL',
+		bankTransferCode: testBankTransferCode,
+		isExported: true,
 	},
 } );

--- a/tests/data/confirmationData.ts
+++ b/tests/data/confirmationData.ts
@@ -109,3 +109,30 @@ export const donationExportedConfirmationData = createConfirmationData( {
 		isExported: true,
 	},
 } );
+
+export const companyExportedPayPalConfirmationData = createConfirmationData( {
+	addressType: 'firma',
+	donation: {
+		paymentType: 'PPL',
+		bankTransferCode: testBankTransferCode,
+		isExported: true,
+	},
+} );
+
+export const anonymousExportedPayPalConfirmationData = createConfirmationData( {
+	addressType: 'anonym',
+	donation: {
+		paymentType: 'PPL',
+		bankTransferCode: testBankTransferCode,
+		isExported: true,
+	},
+} );
+
+export const emailExportedPayPalConfirmationData = createConfirmationData( {
+	addressType: 'anonym',
+	donation: {
+		paymentType: 'PPL',
+		bankTransferCode: testBankTransferCode,
+		isExported: true,
+	},
+} );

--- a/tests/unit/components/pages/donation_confirmation/AddressKnown.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/AddressKnown.spec.ts
@@ -25,9 +25,8 @@ describe( 'AddressKnown', () => {
 
 		expect( wrapper.text() ).toContain( 'donation_confirmation_summary_title' );
 		expect( wrapper.text() ).toContain( 'donation_confirmation_email' );
-		// TODO: Activate these when https://phabricator.wikimedia.org/T316632 is done
-		// expect( wrapper.text() ).toContain( 'donation_confirmation_address_update' );
-		// expect( wrapper.text() ).toContain( 'donation_confirmation_address_update_link' );
+		expect( wrapper.text() ).toContain( 'donation_confirmation_address_update' );
+		expect( wrapper.text() ).toContain( 'donation_confirmation_address_update_link' );
 	} );
 
 	it( 'renders person address for person address type', () => {

--- a/tests/unit/components/pages/donation_confirmation/AddressModal.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/AddressModal.spec.ts
@@ -1,0 +1,216 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import Buefy from 'buefy';
+import { createStore } from '@/store/donation_store';
+import AddressModal from '@/components/pages/donation_confirmation/AddressModal.vue';
+import { action } from '../../../../../src/store/util';
+import { NS_ADDRESS } from '../../../../../src/store/namespaces';
+import { initializeAddress } from '../../../../../src/store/address/actionTypes';
+import { addressValidationPatterns } from '../../../../data/validation';
+import { anonymousBankTransferConfirmationData, bankTransferConfirmationData } from '../../../../data/confirmationData';
+import { Address } from '../../../../../src/view_models/Address';
+import { AddressTypeModel } from '../../../../../src/view_models/AddressTypeModel';
+import { Validity } from '../../../../../src/view_models/Validity';
+
+const localVue = createLocalVue();
+localVue.use( Vuex );
+localVue.use( Buefy );
+
+const anonAddress = {
+	addressType: 'anonym',
+	salutation: '',
+	title: '',
+	firstName: '',
+	lastName: '',
+	fullName: '',
+	companyName: '',
+	street: '',
+	postcode: '',
+	city: '',
+	country: 'DE',
+	email: '',
+};
+
+const validAddress = {
+	addressType: 'person',
+	salutation: 'Herr',
+	title: '',
+	firstName: 'Johnny',
+	lastName: 'Lawrence',
+	fullName: 'Johnny Lawrence',
+	companyName: 'Eagle Fang Karate',
+	street: 'Sesame',
+	postcode: '12345',
+	city: 'Berlin',
+	country: 'DE',
+	email: 'not.a.real.email@domainlalalaxoxoxo.de',
+};
+
+const addressData = ( address: Address, addressType: AddressTypeModel ) => {
+	return {
+		addressType,
+		newsletter: true,
+		fields: [
+			{ name: 'salutation', value: address.salutation, validity: Validity.INCOMPLETE },
+			{ name: 'title', value: address.title, validity: Validity.INCOMPLETE },
+			{ name: 'firstName', value: address.firstName, validity: Validity.INCOMPLETE },
+			{ name: 'lastName', value: address.lastName, validity: Validity.INCOMPLETE },
+			{ name: 'companyName', value: address.companyName, validity: Validity.INCOMPLETE },
+			{ name: 'street', value: address.street, validity: Validity.INCOMPLETE },
+			{ name: 'postcode', value: address.postcode, validity: Validity.INCOMPLETE },
+			{ name: 'city', value: address.city, validity: Validity.INCOMPLETE },
+			{ name: 'country', value: address.country, validity: Validity.INCOMPLETE },
+			{ name: 'email', value: address.email, validity: Validity.INCOMPLETE },
+		],
+	};
+};
+
+describe( 'AddressModal', () => {
+	let wrapper: any;
+	it( 'prefills address data if it exists', async () => {
+		const store = createStore();
+
+		await store.dispatch(
+			action( NS_ADDRESS, initializeAddress ),
+			addressData( validAddress, AddressTypeModel.PERSON )
+		);
+
+		wrapper = await mount( AddressModal, {
+			localVue,
+			propsData: {
+				validateEmailUrl: '',
+				validateAddressUrl: '',
+				hasErrored: false,
+				hasSucceeded: false,
+				addressValidationPatterns,
+				donorResource: {},
+				...bankTransferConfirmationData,
+			},
+			store,
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		expect( ( wrapper.find( '[name="salutationInternal"]' ).element as HTMLInputElement ).value ).toBe( validAddress.salutation );
+		expect( ( wrapper.find( '#title' ).element as HTMLInputElement ).value ).toBe( validAddress.title );
+		expect( ( wrapper.find( '#first-name' ).element as HTMLInputElement ).value ).toBe( validAddress.firstName );
+		expect( ( wrapper.find( '#last-name' ).element as HTMLInputElement ).value ).toBe( validAddress.lastName );
+		expect( ( wrapper.find( '#street' ).element as HTMLInputElement ).value ).toBe( validAddress.street );
+		expect( ( wrapper.find( '#post-code' ).element as HTMLInputElement ).value ).toBe( validAddress.postcode );
+		expect( ( wrapper.find( '#city' ).element as HTMLInputElement ).value ).toBe( validAddress.city );
+		expect( ( wrapper.find( '#country' ).element as HTMLInputElement ).value ).toBe( 'Deutschland' );
+		expect( ( wrapper.find( '#email' ).element as HTMLInputElement ).value ).toBe( validAddress.email );
+		expect( ( wrapper.find( '[name="newsletter"]' ).element as HTMLInputElement ).checked ).toBe( true );
+	} );
+
+	it( 'marks address type invalid if submitted without selecting', async () => {
+		const store = createStore();
+
+		await store.dispatch(
+			action( NS_ADDRESS, initializeAddress ),
+			addressData( anonAddress, AddressTypeModel.ANON )
+		);
+
+		wrapper = await mount( AddressModal, {
+			localVue,
+			propsData: {
+				validateEmailUrl: '',
+				validateAddressUrl: '',
+				hasErrored: false,
+				hasSucceeded: false,
+				addressValidationPatterns,
+				donorResource: {},
+				...anonymousBankTransferConfirmationData,
+			},
+			store,
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		await wrapper.find( '#address-update-form' ).trigger( 'submit' );
+		expect( wrapper.find( '.error-address-type' ).exists() ).toBe( true );
+	} );
+
+	it( 'marks empty address fields invalid if submitted after selecting address type', async () => {
+		const store = createStore();
+
+		await store.dispatch(
+			action( NS_ADDRESS, initializeAddress ),
+			addressData( anonAddress, AddressTypeModel.ANON )
+		);
+
+		wrapper = await mount( AddressModal, {
+			localVue,
+			propsData: {
+				validateEmailUrl: '',
+				validateAddressUrl: '',
+				hasErrored: false,
+				hasSucceeded: false,
+				addressValidationPatterns,
+				donorResource: {},
+				...bankTransferConfirmationData,
+			},
+			store,
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		await wrapper.find( '#address-type-person input' ).trigger( 'change' );
+		await wrapper.find( '#address-update-form' ).trigger( 'submit' );
+
+		await wrapper.vm.$nextTick();
+
+		expect( wrapper.find( '.error-salutation' ).exists() ).toBe( true );
+		expect( wrapper.find( '.error-first-name' ).exists() ).toBe( true );
+		expect( wrapper.find( '.error-last-name' ).exists() ).toBe( true );
+		expect( wrapper.find( '.error-street' ).exists() ).toBe( true );
+		expect( wrapper.find( '.error-postcode' ).exists() ).toBe( true );
+		expect( wrapper.find( '.error-city' ).exists() ).toBe( true );
+		expect( wrapper.find( '.error-email' ).exists() ).toBe( true );
+	} );
+
+	it( 'displays an error if one is returned from the server', async () => {
+		const store = createStore();
+		store.dispatch = jest.fn().mockResolvedValue( { status: 'OK', messages: {} } );
+
+		const error = 'Get outta that garden!';
+		const donorResource = {
+			put: jest.fn().mockRejectedValue( error ),
+		};
+
+		wrapper = await mount( AddressModal, {
+			localVue,
+			propsData: {
+				validateEmailUrl: '',
+				validateAddressUrl: '',
+				hasErrored: false,
+				hasSucceeded: false,
+				addressValidationPatterns,
+				donorResource,
+				...bankTransferConfirmationData,
+			},
+			store,
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		await wrapper.find( '#address-update-form' ).trigger( 'submit' );
+
+		// The submission process goes many promises deep, so wait until they all resolve
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
+
+		expect( wrapper.vm.$data.serverMessage ).toBe( error );
+		expect( wrapper.find( '.error-server' ).exists() ).toBe( true );
+	} );
+} );

--- a/tests/unit/components/pages/donation_confirmation/DonationConfirmation.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/DonationConfirmation.spec.ts
@@ -5,9 +5,11 @@ import DonationConfirmation from '@/components/pages/DonationConfirmation.vue';
 import { createStore } from '@/store/donation_store';
 import { FeatureTogglePlugin } from '@/FeatureToggle';
 import {
-	anonymousBankTransferConfirmationData,
-	bankTransferConfirmationData, donationExportedConfirmationData,
-	emailBankTransferConfirmationData,
+	anonymousBankTransferConfirmationData, anonymousExportedPayPalConfirmationData,
+	bankTransferConfirmationData,
+	companyExportedPayPalConfirmationData,
+	donationExportedConfirmationData,
+	emailBankTransferConfirmationData, emailExportedPayPalConfirmationData,
 	payPalConfirmationData,
 } from '../../../../data/confirmationData';
 
@@ -92,7 +94,7 @@ describe( 'DonationConfirmation', () => {
 		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
 	} );
 
-	it( 'displays donation exported card when donation is exported', () => {
+	it( 'displays donation exported card when donation is exported and person', () => {
 		const wrapper = mount( DonationConfirmation, {
 			localVue,
 			propsData: donationExportedConfirmationData,
@@ -104,6 +106,54 @@ describe( 'DonationConfirmation', () => {
 		} );
 
 		expect( wrapper.find( '.exported-donation' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '.known-address' ).exists() ).toBeFalsy();
+		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
+	} );
+
+	it( 'displays donation exported card when donation is exported and company', () => {
+		const wrapper = mount( DonationConfirmation, {
+			localVue,
+			propsData: companyExportedPayPalConfirmationData,
+			store: createStore(),
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		expect( wrapper.find( '.exported-donation' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '.known-address' ).exists() ).toBeFalsy();
+		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
+	} );
+
+	it( 'does not display donation exported card when donation is anonymous', () => {
+		const wrapper = mount( DonationConfirmation, {
+			localVue,
+			propsData: anonymousExportedPayPalConfirmationData,
+			store: createStore(),
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		expect( wrapper.find( '.exported-donation' ).exists() ).toBeFalsy();
+		expect( wrapper.find( '.known-address' ).exists() ).toBeFalsy();
+		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
+	} );
+
+	it( 'does not display donation exported card when donation is email', () => {
+		const wrapper = mount( DonationConfirmation, {
+			localVue,
+			propsData: emailExportedPayPalConfirmationData,
+			store: createStore(),
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		expect( wrapper.find( '.exported-donation' ).exists() ).toBeFalsy();
 		expect( wrapper.find( '.known-address' ).exists() ).toBeFalsy();
 		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
 	} );

--- a/tests/unit/components/pages/donation_confirmation/DonationConfirmation.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/DonationConfirmation.spec.ts
@@ -6,7 +6,7 @@ import { createStore } from '@/store/donation_store';
 import { FeatureTogglePlugin } from '@/FeatureToggle';
 import {
 	anonymousBankTransferConfirmationData,
-	bankTransferConfirmationData,
+	bankTransferConfirmationData, donationExportedConfirmationData,
 	emailBankTransferConfirmationData,
 	payPalConfirmationData,
 } from '../../../../data/confirmationData';
@@ -89,6 +89,22 @@ describe( 'DonationConfirmation', () => {
 		} );
 
 		expect( wrapper.find( '.known-address' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
+	} );
+
+	it( 'displays donation exported card when donation is exported', () => {
+		const wrapper = mount( DonationConfirmation, {
+			localVue,
+			propsData: donationExportedConfirmationData,
+			store: createStore(),
+			mocks: {
+				$t: ( key: string ) => key,
+				$n: () => {},
+			},
+		} );
+
+		expect( wrapper.find( '.exported-donation' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '.known-address' ).exists() ).toBeFalsy();
 		expect( wrapper.find( '.anonymous-address' ).exists() ).toBeFalsy();
 	} );
 


### PR DESCRIPTION
Donors can now update their address any time before
the donation is exported.
Ticket (address update): https://phabricator.wikimedia.org/T316632
Ticket (is exported): https://phabricator.wikimedia.org/T326246