### PR TITLE
Fix unset address type - donation summary box

### DIFF
--- a/src/components/shared/DonationSummary.vue
+++ b/src/components/shared/DonationSummary.vue
@@ -17,6 +17,7 @@
 import Vue from 'vue';
 import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
 import PaymentSummaryAnonymous from '@/components/shared/payment_summary/PaymentSummaryAnonymous.vue';
+import PaymentSummaryUnset from '@/components/shared/payment_summary/PaymentSummaryUnset.vue';
 import PaymentSummaryCompany from '@/components/shared/payment_summary/PaymentSummaryCompany.vue';
 import PaymentSummaryEmail from '@/components/shared/payment_summary/PaymentSummaryEmail.vue';
 import PaymentSummaryPrivate from '@/components/shared/payment_summary/PaymentSummaryPrivate.vue';
@@ -26,7 +27,7 @@ const addressTypeComponents = {
 	[ addressTypeName( AddressTypeModel.COMPANY ) ]: PaymentSummaryCompany,
 	[ addressTypeName( AddressTypeModel.EMAIL ) ]: PaymentSummaryEmail,
 	[ addressTypeName( AddressTypeModel.PERSON ) ]: PaymentSummaryPrivate,
-	[ addressTypeName( AddressTypeModel.UNSET ) ]: PaymentSummaryAnonymous,
+	[ addressTypeName( AddressTypeModel.UNSET ) ]: PaymentSummaryUnset,
 };
 
 export default Vue.extend( {

--- a/src/components/shared/payment_summary/PaymentSummaryUnset.vue
+++ b/src/components/shared/payment_summary/PaymentSummaryUnset.vue
@@ -1,0 +1,37 @@
+<template>
+	<div class="payment-summary" v-html="getSummary"></div>
+</template>
+
+<script>
+export default {
+	name: 'PaymentSummaryAnonymous',
+	props: [
+		'address',
+		'interval',
+		'formattedAmount',
+		'paymentType',
+		'country',
+		'languageItem',
+		'email',
+	],
+	computed: {
+		getSummary: function () {
+			return this.$t(
+				this.$props.languageItem,
+				{
+					interval: this.$props.interval,
+					formattedAmount: this.$props.formattedAmount,
+					paymentType: this.$props.paymentType,
+					personType: '',
+					address: '',
+					email: '',
+				}
+			);
+		},
+	},
+};
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
- The box summarizes the user's input.
- As long as no address type is selected, the summary box doesn't show any address type value.
- Ticket: https://phabricator.wikimedia.org/T329351