### PR TITLE
Add formatted bank number field

### DIFF
--- a/src/components/shared/AccountNumberField.vue
+++ b/src/components/shared/AccountNumberField.vue
@@ -1,0 +1,59 @@
+<template>
+	<input
+		id="iban"
+		class="input"
+		:placeholder="placeholder"
+		:value="displayValue"
+		@blur="$emit( 'validate' )"
+		@input="onInput"
+		@paste="onInput"
+	/>
+</template>
+
+<script setup lang="ts">
+
+import { ref, watch } from 'vue';
+
+interface Props {
+	id?: string;
+	placeholder: string;
+	accountId: string;
+	characterGroupSize?: number;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+	id: 'iban',
+	characterGroupSize: 4,
+} );
+
+const emit = defineEmits( [ 'input', 'validate' ] );
+
+const getDisplayValue = ( newValue: string ) => {
+	const characters = newValue.split( '' );
+
+	let newFormattedValue = '';
+	for ( let i = 0; i < characters.length; i++ ) {
+		newFormattedValue += characters[ i ];
+
+		if ( ( i + 1 ) % props.characterGroupSize === 0 ) {
+			newFormattedValue += ' ';
+		}
+	}
+
+	return newFormattedValue;
+};
+
+const displayValue = ref( getDisplayValue( props.accountId ) );
+
+watch( () => props.accountId, ( newValue: string ) => {
+	displayValue.value = getDisplayValue( newValue );
+} );
+
+const onInput = ( e: Event ) => {
+	const newValue = ( e.target as HTMLInputElement ).value
+		.replace( /\s/g, '' );
+
+	emit( 'input', newValue );
+};
+
+</script>

--- a/src/components/shared/PaymentBankData.vue
+++ b/src/components/shared/PaymentBankData.vue
@@ -3,20 +3,17 @@
 		<legend class="title is-size-5">{{ $t( 'donation_form_payment_bankdata_title' ) }}</legend>
 		<div v-bind:class="['form-input', { 'is-invalid': bankDataIsInvalid }]">
 			<label for="iban" class="subtitle">{{ $t( labels.iban ) }}</label>
-			<b-field v-bind:class="[{ 'has-margin-bottom-0': !isBankFieldEnabled }]">
-				<b-input
-					class="is-medium"
-					data-content-name="Bank Data Type"
-					:data-track-content="getTrackingCode !== ''"
-					:data-content-piece="getTrackingCode"
-					type="text"
-					id="iban"
-					v-model="accountId"
-					name="iban"
-					:placeholder="$t( 'donation_form_payment_bankdata_account_iban_placeholder' )"
-					@blur="validate">
-				</b-input>
-			</b-field>
+			<div class="field" :class="[ { 'has-margin-bottom-0': !isBankFieldEnabled } ]">
+				<div class="control is-medium is-clearfix">
+					<AccountNumberField
+						:id="'iban'"
+						:placeholder="$t( 'donation_form_payment_bankdata_account_iban_placeholder' ).toString()"
+						:account-id="accountId"
+						@validate="validate"
+						@input="setAccountId"
+					/>
+				</div>
+			</div>
 		</div>
 		<div v-bind:class="['form-input', { 'is-invalid': bankDataIsInvalid }]" v-show="isBankFieldEnabled">
 			<label for="bic" class="subtitle">{{ $t( labels.bic ) }}</label>
@@ -54,9 +51,11 @@ import { markBankDataAsIncomplete, markBankDataAsInvalid, setBankData } from '@/
 import { NS_BANKDATA } from '@/store/namespaces';
 import { action } from '@/store/util';
 import { mapGetters } from 'vuex';
+import AccountNumberField from '@/components/shared/AccountNumberField.vue';
 
 export default Vue.extend( {
 	name: 'PaymentBankData',
+	components: { AccountNumberField },
 	data: function (): BankAccountData {
 		return {
 			accountId: this.$store.getters[ NS_BANKDATA + '/getAccountId' ],
@@ -162,6 +161,9 @@ export default Vue.extend( {
 						} as BankAccountRequest
 				);
 			}
+		},
+		setAccountId: function ( accountId: string ) {
+			this.$data.accountId = accountId;
 		},
 		isAccountIdEmpty: function () {
 			return this.$data.accountId === '';

--- a/tests/unit/components/shared/AccountNumberField.spec.ts
+++ b/tests/unit/components/shared/AccountNumberField.spec.ts
@@ -1,0 +1,60 @@
+import AccountNumberField from '@/components/shared/AccountNumberField.vue';
+import { mount, Wrapper } from '@vue/test-utils';
+import { nextTick } from 'vue';
+
+const IBAN_VALUE = 'DE12500105170648489890';
+const IBAN_DISPLAY = 'DE12 5001 0517 0648 4898 90';
+
+describe( 'AccountNumberField.vue', () => {
+
+	const getWrapper = ( accountId: string = '' ): Wrapper<any> => {
+		return mount( AccountNumberField, {
+			propsData: {
+				placeholder: '',
+				accountId,
+			},
+		} );
+	};
+
+	it( 'Sets the initial value when mounted', async () => {
+		const wrapper = getWrapper( IBAN_VALUE );
+
+		await nextTick();
+
+		expect( wrapper.find<HTMLInputElement>( '#iban' ).element.value ).toBe( IBAN_DISPLAY );
+	} );
+
+	it( 'inserts spaces into field every 4 characters', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.setProps( { accountId: IBAN_VALUE } );
+
+		expect( wrapper.find<HTMLInputElement>( '#iban' ).element.value ).toBe( IBAN_DISPLAY );
+	} );
+
+	it( 'emits input event', async () => {
+		const wrapper = getWrapper();
+		const field = wrapper.find<HTMLInputElement>( '#iban' );
+
+		await field.setValue( IBAN_VALUE );
+
+		const emitted = wrapper.emitted( 'input' );
+
+		if ( emitted === undefined ) {
+			fail( 'the event did not fire' );
+		} else {
+			expect( emitted.length ).toBe( 1 );
+			expect( emitted[ 0 ][ 0 ] ).toEqual( IBAN_VALUE );
+		}
+	} );
+
+	it( 'emits validate event', async () => {
+		const wrapper = getWrapper();
+		const field = wrapper.find<HTMLInputElement>( '#iban' );
+
+		await field.setValue( IBAN_VALUE );
+		await field.trigger( 'blur' );
+
+		expect( wrapper.emitted( 'validate' )?.length ).toBe( 1 );
+	} );
+} );

--- a/tests/unit/components/shared/BankData.spec.ts
+++ b/tests/unit/components/shared/BankData.spec.ts
@@ -17,6 +17,8 @@ const localVue = createLocalVue();
 localVue.use( Vuex );
 localVue.use( Buefy );
 
+const translator = ( key: string ) => key;
+
 describe( 'BankData', () => {
 
 	it( 'validates IBANs correctly and sets the bank data to the store on success', () => {
@@ -28,7 +30,7 @@ describe( 'BankData', () => {
 			},
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		const store = wrapper.vm.$store;
@@ -55,7 +57,7 @@ describe( 'BankData', () => {
 			},
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		const store = wrapper.vm.$store;
@@ -82,7 +84,7 @@ describe( 'BankData', () => {
 			},
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		const store = wrapper.vm.$store;
@@ -112,7 +114,7 @@ describe( 'BankData', () => {
 			},
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		const store = wrapper.vm.$store;
@@ -135,7 +137,7 @@ describe( 'BankData', () => {
 			},
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		const store = wrapper.vm.$store;
@@ -157,7 +159,7 @@ describe( 'BankData', () => {
 			localVue,
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 
@@ -166,7 +168,7 @@ describe( 'BankData', () => {
 		wrapper.setData( { accountId: 'AT12345605171238489890', bankId: 'ABCDDEFFXXX' } );
 		await wrapper.vm.$nextTick();
 
-		expect( ( ( <HTMLInputElement> iban.element ).value ) ).toMatch( 'AT12345605171238489890' );
+		expect( ( ( <HTMLInputElement> iban.element ).value ) ).toMatch( 'AT12 3456 0517 1238 4898 90' );
 		expect( ( ( <HTMLInputElement> bic.element ).value ) ).toMatch( 'ABCDDEFFXXX' );
 	} );
 
@@ -175,7 +177,7 @@ describe( 'BankData', () => {
 			localVue,
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		const store = wrapper.vm.$store;
@@ -193,6 +195,7 @@ describe( 'BankData', () => {
 			bankDataIsInvalid: () => false,
 			getBankName: () => '',
 			getBankId: () => '',
+			getAccountId: () => '',
 		};
 		store = new Vuex.Store( {
 			modules: {
@@ -209,7 +212,7 @@ describe( 'BankData', () => {
 			localVue,
 			store,
 			mocks: {
-				$t: ( key: string ) => key,
+				$t: translator,
 			},
 		} );
 
@@ -217,6 +220,7 @@ describe( 'BankData', () => {
 		const iban = wrapper.find( '#iban' );
 		iban.trigger( 'blur' );
 		await wrapper.vm.$nextTick();
+
 		const bicInfo = wrapper.find( '#bank-name-not-available' );
 		expect( bicInfo.text() )
 			.toMatch( 'donation_form_payment_bankdata_bank_bic_placeholder_full' );
@@ -227,7 +231,7 @@ describe( 'BankData', () => {
 			localVue,
 			store: createStore(),
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 
@@ -248,6 +252,7 @@ describe( 'BankData', () => {
 			bankDataIsValid: () => true,
 			bankDataIsInvalid: () => false,
 			getBankName: () => 'gute Bank',
+			getAccountId: () => '',
 		};
 		store = new Vuex.Store( {
 			modules: {
@@ -261,7 +266,7 @@ describe( 'BankData', () => {
 			localVue,
 			store,
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		wrapper.setData( { accountId: 'DE89370400440532013000' } );
@@ -277,6 +282,7 @@ describe( 'BankData', () => {
 			bankDataIsValid: () => false,
 			bankDataIsInvalid: () => true,
 			getBankName: () => '',
+			getAccountId: () => '',
 		};
 		store = new Vuex.Store( {
 			modules: {
@@ -290,7 +296,7 @@ describe( 'BankData', () => {
 			localVue,
 			store,
 			mocks: {
-				$t: () => {},
+				$t: translator,
 			},
 		} );
 		wrapper.setData( { accountId: 'DE89370400440532013000' } );
@@ -304,7 +310,7 @@ describe( 'BankData', () => {
 			localVue,
 			store: createStore(),
 			mocks: {
-				$t: ( key: string ) => key,
+				$t: translator,
 			},
 		} );
 
@@ -318,7 +324,7 @@ describe( 'BankData', () => {
 			localVue,
 			store: createStore(),
 			mocks: {
-				$t: ( key: string ) => key,
+				$t: translator,
 			},
 		} );
 
@@ -334,7 +340,7 @@ describe( 'BankData', () => {
 			localVue,
 			store: createStore(),
 			mocks: {
-				$t: ( key: string ) => key,
+				$t: translator,
 			},
 		} );
 
@@ -356,14 +362,14 @@ describe( 'BankData', () => {
 				localVue,
 				store,
 				mocks: {
-					$t: ( key: string ) => key,
+					$t: translator,
 				},
 			} );
 			const iban = wrapper.find( '#iban' );
 			const bic = wrapper.find( '#bic' );
 			const bankName = wrapper.find( '#bank-name-iban' );
 
-			expect( ( ( <HTMLInputElement> iban.element ).value ) ).toMatch( 'DE12345605171238489890' );
+			expect( ( ( <HTMLInputElement> iban.element ).value ) ).toMatch( 'DE12 3456 0517 1238 4898 90' );
 			expect( ( ( <HTMLInputElement> bic.element ).value ) ).toMatch( 'ABCDDEFFXXX' );
 			expect( ( ( <HTMLElement> bankName.element ).textContent ) ).toMatch( 'Cool Bank' );
 		} );


### PR DESCRIPTION
This adds a field that formats the bank account
number by adding a space every 4 characters. It
will still emit the number with whitespace cleared.

Ticket: https://phabricator.wikimedia.org/T339107