### PR TITLE
UoF: Use SVG file provided from content

### DIFF
--- a/src/components/pages/UseOfFunds.vue
+++ b/src/components/pages/UseOfFunds.vue
@@ -47,7 +47,7 @@
 				</div>
 			</div>
 			<div class="use_of_funds__orgchart_image">
-				<img :src="assetsPath + '/images/WMDE-funds-forwarding.gif'" />
+				<img :src="'/resources/'+$i18n.locale.replace('-', '_')+'/WMDE-funds-forwarding.svg'" :alt="content.orgchart.imageAltText" />
 			</div>
 		</div>
 		<div class="banner_model__section use_of_funds__section--call_to_action">


### PR DESCRIPTION
The use of funds page should use an SVG file instead of a GIF for the money forwarding illustration.
The SVG files for both languages were uploaded to wikimedia commons and their links are stored in fundraising-frontend-content

related content change: https://github.com/wmde/fundraising-frontend-content/pull/230

https://phabricator.wikimedia.org/T342841