### PR TITLE
[FollowUp] Use RadioField component on Payment page

### DIFF
--- a/src/components/pages/donation_form/Payment.vue
+++ b/src/components/pages/donation_form/Payment.vue
@@ -8,32 +8,32 @@
 			:show-error="amountErrorMessage !== ''"
 		/>
 
-    <div class="title is-size-5">{{ $t('donation_form_payment_interval_title') }}</div>
+		<div class="title is-size-5">{{ $t('donation_form_payment_interval_title') }}</div>
 		<RadioField
 			name="interval"
 			v-model="interval"
 			:options="paymentIntervalsAsOptions"
 			:required="true"
 			:disabled="disabledPaymentIntervals"
-			alignment="column"
-			:label="$t('donation_form_payment_interval_title')">
+			alignment="column">
 		</RadioField>
 
-		<PaymentType
-			class="has-margin-top-36"
-			:current-type="paymentType"
-			:payment-types="paymentTypes"
-			:error="paymentTypeIsValid ? '' : $t('donation_form_payment_type_error')"
-			:title="$t('donation_form_payment_type_title')"
-			:disabled-payment-types="disabledPaymentTypes"
-			v-on:payment-type-selected="sendTypeToStore"
-		/>
+		<div class="title is-size-5">{{ $t('donation_form_payment_type_title') }}</div>
+		<RadioField
+			name="paymentType"
+			v-model="paymentType"
+			:options="paymentTypesAsOptions"
+			:required="true"
+			:disabled="disabledPaymentTypes"
+			alignment="column"
+			:show-error="paymentTypeIsValid"
+			:error-message="$t('donation_form_payment_type_error')">
+		</RadioField>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import PaymentType from '@src/components/pages/donation_form/PaymentType.vue';
 import { action } from '@src/store/util';
 import { NS_ADDRESS, NS_PAYMENT } from '@src/store/namespaces';
 import { setAmount, setInterval, setType } from '@src/store/payment/actionTypes';
@@ -62,7 +62,9 @@ const amount = ref<string>( amountFromStore.value );
 const intervalFromStore = computed<string>( () => store.state[ NS_PAYMENT ].values.interval );
 const interval = ref<string>( intervalFromStore.value );
 
-const paymentType = computed<string>( () => store.state[ NS_PAYMENT ].values.type );
+const paymentTypeFromStore = computed<string>( () => store.state[ NS_PAYMENT ].values.type );
+const paymentType = ref<string>( paymentTypeFromStore.value );
+
 const paymentTypeIsValid = computed<boolean>( () => store.state[ NS_PAYMENT ].validity.type );
 const disabledPaymentTypes = computed<string[]>( () => {
 	let disabledTypes : string[] = [];
@@ -81,6 +83,14 @@ const paymentIntervalsAsOptions = computed<FormOption[]>( () => {
 			{ value: intervalValue.toString(), label: t( 'donation_form_payment_interval_' + intervalValue ) }
 		) );
 } );
+
+const paymentTypesAsOptions = computed<FormOption[]>( () => {
+	return props.paymentTypes.map(
+		( paymentTypeValue: string ) => (
+			{ value: paymentTypeValue, label: t( paymentTypeValue ) }
+		) );
+} );
+
 const disabledPaymentIntervals = computed<string[]>( () => {
 	let disabledIntervals : string[] = [];
 	if ( store.state[ NS_PAYMENT ].values.type === 'SUB' ) {
@@ -117,5 +127,10 @@ watch( amountFromStore, ( newValue ) => {
 watch( interval, sendIntervalToStore );
 watch( intervalFromStore, ( newValue ) => {
 	interval.value = newValue;
+} );
+
+watch( paymentType, sendTypeToStore );
+watch( paymentTypeFromStore, ( newValue ) => {
+	paymentType.value = newValue;
 } );
 </script>

--- a/src/components/shared/form_fields/AmountField.vue
+++ b/src/components/shared/form_fields/AmountField.vue
@@ -10,6 +10,7 @@
 				name="amount"
 				v-model="amount"
 				:class="{ 'inactive': paymentAmount < minimumAmount }"
+				@update:modelValue="onFieldChange"
 			>
 				{{ $n( paymentAmount / 100, 'euros' ) }}
 			</RadioFormInput>
@@ -23,6 +24,7 @@
 				:has-message="false"
 				name="custom-amount"
 				:placeholder="$t('donation_form_custom_placeholder')"
+				@update:modelValue="onFieldChange"
 			/>
 			<label for="form-field-amount-custom">{{ $t('donation_form_payment_amount_legend') }}</label>
 		</div>
@@ -50,6 +52,7 @@ const props = withDefaults( defineProps<Props>(), {
 	minimumAmount: 0,
 	showError: false,
 } );
+const emit = defineEmits( [ 'update:modelValue', 'field-changed' ] );
 
 const amount = ref<string>( props.modelValue );
 const customAmount = ref<string>( props.modelValue );
@@ -57,6 +60,11 @@ const customAmount = ref<string>( props.modelValue );
 watch( () => props.modelValue, ( newValue: string ) => {
 	amount.value = newValue;
 } );
+
+const onFieldChange = ( newValue: string | number | boolean | null ): void => {
+	emit( 'update:modelValue', newValue );
+	emit( 'field-changed', 'amount' );
+};
 
 </script>
 

--- a/src/components/shared/form_fields/RadioField.vue
+++ b/src/components/shared/form_fields/RadioField.vue
@@ -1,6 +1,6 @@
 <template>
 	<fieldset class="form-field form-field-radio" :class="{ 'is-invalid': showError }">
-		<legend class="form-field-label">{{ label }}</legend>
+		<legend v-if="label" class="form-field-label">{{ label }}</legend>
 		<div class="control form-field-radio-container" :class="alignment+ '-alignment'">
 			<RadioFormInput
 				v-for="( option, index ) in options"
@@ -28,7 +28,7 @@ import RadioFormInput from '@src/components/shared/form_inputs/RadioFormInput.vu
 import { useFieldModel } from '@src/components/shared/form_fields/useFieldModel';
 
 interface Props {
-	label: String;
+	label?: String;
 	name: string;
 	modelValue: string | number | boolean | null;
 	options: FormOption[];
@@ -36,7 +36,7 @@ interface Props {
 	required?: boolean;
 	showError?: boolean;
 	errorMessage?: String;
-  alignment: 'row' | 'column';
+	alignment: 'row' | 'column';
 }
 
 const props = withDefaults( defineProps<Props>(), {
@@ -56,5 +56,36 @@ const onFieldChange = ( newValue: string | number | boolean | null ): void => {
 </script>
 
 <style lang="scss">
+@use '@src/scss/settings/units';
+@use 'sass:map';
+
+.form-field-radio {
+	&-container {
+		display: flex;
+		.radio + .radio {
+			margin: 0;
+		}
+		&.row-alignment {
+			flex-direction: row;
+		}
+		&.column-alignment {
+			flex-direction: column;
+			.radio-form-input {
+				width: 350px;
+				border-bottom: 2px solid rgba(0, 0, 0, 0.14);
+				padding-top: map.get( units.$spacing, 'medium' );
+				.check {
+					margin-right: map.get( units.$spacing, 'small' );
+				}
+				&.is-active {
+					border-bottom: 2px solid #0065a4;
+				}
+				&:hover {
+					border-bottom: 2px solid #808080;
+				}
+			}
+		}
+	}
+}
 
 </style>

--- a/src/components/shared/form_fields/RadioField.vue
+++ b/src/components/shared/form_fields/RadioField.vue
@@ -1,7 +1,7 @@
 <template>
 	<fieldset class="form-field form-field-radio" :class="{ 'is-invalid': showError }">
 		<legend class="form-field-label">{{ label }}</legend>
-		<div class="control form-field-radio-container">
+		<div class="control form-field-radio-container" :class="alignment+ '-alignment'">
 			<RadioFormInput
 				v-for="( option, index ) in options"
 				:key="index"
@@ -36,6 +36,7 @@ interface Props {
 	required?: boolean;
 	showError?: boolean;
 	errorMessage?: String;
+  alignment: 'row' | 'column';
 }
 
 const props = withDefaults( defineProps<Props>(), {

--- a/src/scss/components/form_field.scss
+++ b/src/scss/components/form_field.scss
@@ -30,26 +30,6 @@
 		line-height: map.get( forms.$label, 'line-height' );
 	}
 
-	&-radio-container {
-		display: flex;
-		&.row-alignment {
-			flex-direction: row;
-		}
-		&.column-alignment {
-			flex-direction: column;
-			.radio-form-input {
-				width: 350px;
-				border-bottom: 2px solid rgba(0, 0, 0, 0.14);
-				&.is-active {
-					border-bottom: 2px solid #0065a4;
-				}
-				&:hover {
-					border-bottom: 2px solid #808080;
-				}
-			}
-		}
-	}
-
 	&-select {
 		.select:not( .is-multiple ) {
 			height: auto;

--- a/src/scss/components/form_field.scss
+++ b/src/scss/components/form_field.scss
@@ -32,6 +32,22 @@
 
 	&-radio-container {
 		display: flex;
+		&.row-alignment {
+			flex-direction: row;
+		}
+		&.column-alignment {
+			flex-direction: column;
+			.radio-form-input {
+				width: 350px;
+				border-bottom: 2px solid rgba(0, 0, 0, 0.14);
+				&.is-active {
+					border-bottom: 2px solid #0065a4;
+				}
+				&:hover {
+					border-bottom: 2px solid #808080;
+				}
+			}
+		}
 	}
 
 	&-select {


### PR DESCRIPTION
- we have the new RadioField component that encapsulates more of our needed behaviour
- the Payment form component should also use this new component instead of the legacy RadioInput component
- followup for https://github.com/wmde/fundraising-app-frontend/pull/185