### PR TITLE
[Fix] Use hidden submitvalue fields rather than html field names

### DIFF
--- a/src/components/pages/donation_form/DonationReceipt/useAddressFormEventHandlers.ts
+++ b/src/components/pages/donation_form/DonationReceipt/useAddressFormEventHandlers.ts
@@ -6,7 +6,7 @@ import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
 import { markEmptyValuesAsInvalid } from '@src/store/bankdata/actionTypes';
 import { waitForServerValidationToFinish } from '@src/wait_for_server_validation';
 import { discardInitialization } from '@src/store/payment/actionTypes';
-import { ComputedRef, Ref } from 'vue';
+import { ComputedRef, ref, Ref } from 'vue';
 
 const scrollToFirstError = () => {
 	document.getElementsByClassName( 'help is-danger' )[ 0 ]
@@ -16,6 +16,7 @@ const scrollToFirstError = () => {
 type ReturnType = {
 	submit: () => Promise<void>,
 	previousPage: () => void,
+	submitValuesForm: Ref<HTMLFormElement>,
 }
 
 export function useAddressFormEventHandlers(
@@ -23,9 +24,9 @@ export function useAddressFormEventHandlers(
 	emit: ( eventName: string ) => void,
 	isDirectDebit: ComputedRef<any>,
 	validateAddressUrl: string,
-	validateEmailUrl: string,
-	submitForm: Ref<HTMLFormElement>
+	validateEmailUrl: string
 ): ReturnType {
+	const submitValuesForm = ref<HTMLFormElement>();
 	const submit = async () => {
 		const validationCalls: Promise<any>[] = [
 			store.dispatch( action( NS_ADDRESS, validateAddressType ), {
@@ -54,7 +55,7 @@ export function useAddressFormEventHandlers(
 			return;
 		}
 
-		submitForm.value.submit();
+		submitValuesForm.value.submit();
 	};
 
 	const previousPage = async () => {
@@ -65,5 +66,6 @@ export function useAddressFormEventHandlers(
 	return {
 		submit,
 		previousPage,
+		submitValuesForm,
 	};
 }

--- a/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
+++ b/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
@@ -10,7 +10,7 @@
 			@previous-page="previousPage">
 		</PaymentSummary>
 
-		<form @submit="submit" action="/donation/add" method="post">
+		<form @submit.prevent="submit" action="/donation/add" method="post">
 			<AutofillHandler @autofill="onAutofill">
 
 				<PaymentBankData
@@ -104,16 +104,9 @@
 					</div>
 				</template>
 			</FormSummary>
-
-			<input type="hidden" name="addressType" :value="addressTypeName">
-			<input type="hidden" name="paymentType" :value="paymentType">
-			<input type="hidden" name="interval" :value="interval">
-			<input type="hidden" name="amount" :value="amount">
-			<input type="hidden" name="impCount" :value="trackingData.impressionCount">
-			<input type="hidden" name="bImpCount" :value="trackingData.bannerImpressionCount">
-			<input type="hidden" name="piwik_campaign" :value="campaignValues.campaign">
-			<input type="hidden" name="piwik_kwd" :value="campaignValues.keyword">
-
+		</form>
+		<form id="donation-form-submit-values" ref="submitValuesForm" action="/donation/add" method="post">
+			<submit-values :tracking-data="trackingData" :campaign-values="campaignValues"></submit-values>
 		</form>
 	</div>
 </template>
@@ -147,11 +140,11 @@ import { useAddressType } from '@src/components/pages/donation_form/DonationRece
 import { useAddressTypeFromReceiptSetter } from '@src/components/pages/donation_form/DonationReceipt/useAddressTypeFromReceiptSetter';
 import { useMailingListModel } from '@src/components/pages/donation_form/DonationReceipt/useMailingListModel';
 import { usePaymentFunctions } from '@src/components/pages/donation_form/usePaymentFunctions';
-import { usePaymentValues } from '@src/components/pages/donation_form/DonationReceipt/usePaymentValues';
 import { useReceiptModel } from '@src/components/pages/donation_form/DonationReceipt/useReceiptModel';
 import { useStore } from 'vuex';
 import PaymentTextFormButton from '@src/components/shared/form_elements/PaymentTextFormButton.vue';
 import FormSummary from '@src/components/shared/FormSummary.vue';
+import SubmitValues from '@src/components/pages/donation_form/SubmitValues.vue';
 
 interface Props {
 	assetsPath: string;
@@ -172,10 +165,10 @@ const store = useStore( StoreKey );
 
 const { addressType, addressTypeName } = useAddressType( store );
 const { addressSummary, inlineSummaryLanguageItem } = useAddressSummary( store );
-const { amount, interval, paymentType } = usePaymentValues( store );
 const mailingList = useMailingListModel( store );
 const { receiptNeeded, showReceiptOptionError } = useReceiptModel( store );
 const countryWasRestored = ref<boolean>( false );
+const submitValuesForm = ref<HTMLFormElement>();
 
 const {
 	formData,
@@ -193,7 +186,7 @@ const {
 	paymentWasInitialized,
 } = usePaymentFunctions( store );
 
-const { submit, previousPage } = useAddressFormEventHandlers( store, emit, isDirectDebitPayment, props.validateAddressUrl, props.validateEmailUrl );
+const { submit, previousPage } = useAddressFormEventHandlers( store, emit, isDirectDebitPayment, props.validateAddressUrl, props.validateEmailUrl, submitValuesForm );
 
 useAddressTypeFromReceiptSetter( receiptNeeded, addressType, store );
 

--- a/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
+++ b/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
@@ -168,7 +168,6 @@ const { addressSummary, inlineSummaryLanguageItem } = useAddressSummary( store )
 const mailingList = useMailingListModel( store );
 const { receiptNeeded, showReceiptOptionError } = useReceiptModel( store );
 const countryWasRestored = ref<boolean>( false );
-const submitValuesForm = ref<HTMLFormElement>();
 
 const {
 	formData,
@@ -186,7 +185,8 @@ const {
 	paymentWasInitialized,
 } = usePaymentFunctions( store );
 
-const { submit, previousPage } = useAddressFormEventHandlers( store, emit, isDirectDebitPayment, props.validateAddressUrl, props.validateEmailUrl, submitValuesForm );
+const { submit, previousPage, submitValuesForm } =
+	useAddressFormEventHandlers( store, emit, isDirectDebitPayment, props.validateAddressUrl, props.validateEmailUrl );
 
 useAddressTypeFromReceiptSetter( receiptNeeded, addressType, store );
 


### PR DESCRIPTION
- the form should submit the values collected in SubmitValues.vue

- the code from both useAddressFormEventHandlers was adjusted to not diverge too much

- trackFormSubmission() is removed from the DonationReceipt bucket because the tracking currently does not work there

- extends (+ fixes broken bank account number submission in) https://github.com/wmde/fundraising-app-frontend/pull/182

belongs to the changes in https://phabricator.wikimedia.org/T345528