### PR TITLE
Fix bug in the new address page

### DIFF
--- a/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
+++ b/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
@@ -50,7 +50,6 @@
 						{ value: false, label: $t( 'no' ) },
 					]"
 					:label="$t( 'donation_confirmation_cta_title_alt' )"
-					@field-changed="onFieldChange"
 					:show-error="showReceiptOptionError"
 					:error-message="$t( 'C23_WMDE_Desktop_DE_05_receipt_error' )"
 					alignment="row"


### PR DESCRIPTION
The store contains an array of fields that contain a donors address. The newsletter option isn't part of that so it was throwing errors.