### PR TITLE
Remove summary notice below submit buttons

### DIFF
--- a/src/components/pages/donation_form/subpages/AddressPage.vue
+++ b/src/components/pages/donation_form/subpages/AddressPage.vue
@@ -91,14 +91,6 @@
 				/>
 			</template>
 
-			<template #summary-notice>
-				<div class="form-summary-notice" v-if="isExternalPayment">
-					{{ $t( 'donation_form_summary_external_payment' ) }}
-				</div>
-				<div class="form-summary-notice" v-if="isBankTransferPayment">
-					{{ $t( 'donation_form_summary_bank_transfer_payment' ) }}
-				</div>
-			</template>
 		</FormSummary>
 		<form action="/donation/add" method="post" ref="submitValuesForm">
 			<submit-values :tracking-data="trackingData" :campaign-values="campaignValues"></submit-values>
@@ -167,8 +159,6 @@ const {
 
 const {
 	isDirectDebitPayment,
-	isBankTransferPayment,
-	isExternalPayment,
 	paymentSummary,
 	paymentWasInitialized,
 } = usePaymentFunctions( store );

--- a/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
+++ b/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
@@ -94,15 +94,6 @@
 						@click="submit"
 					/>
 				</template>
-
-				<template #summary-notice>
-					<div class="form-summary-notice" v-if="isExternalPayment">
-						{{ $t( 'donation_form_summary_external_payment' ) }}
-					</div>
-					<div class="form-summary-notice" v-if="isBankTransferPayment">
-						{{ $t( 'donation_form_summary_bank_transfer_payment' ) }}
-					</div>
-				</template>
 			</FormSummary>
 		</form>
 		<form id="donation-form-submit-values" ref="submitValuesForm" action="/donation/add" method="post">
@@ -178,9 +169,7 @@ const {
 } = useAddressFunctions( { addressValidationPatterns: props.addressValidationPatterns }, store );
 
 const {
-	isBankTransferPayment,
 	isDirectDebitPayment,
-	isExternalPayment,
 	paymentSummary,
 	paymentWasInitialized,
 } = usePaymentFunctions( store );


### PR DESCRIPTION
- these were removed in the original PR of this ticket https://phabricator.wikimedia.org/T344426 but slipped in again

- due to the dynamic button text the summary is not necessary anymore

- the summary notice should be removed for ap=0 and ap=1