### PR TITLE
Fix comment list

### DIFF
--- a/src/components/pages/CommentList.vue
+++ b/src/components/pages/CommentList.vue
@@ -7,7 +7,7 @@
 		</span>
 		<div class="has-margin-top-18">
 			<div class="has-margin-top-18" v-for="comment in pageContent">
-				<div class="has-text-weight-bold">{{ $t( 'donation_comments_donor_headline', headlineVars( comment ) )}}</div>
+				<div class="has-text-weight-bold">{{ commentHeadline( comment ) }}</div>
 				<div class="has-text-gray-dark">{{ comment.date }}</div>
 				<div>{{ comment.comment }}</div>
 			</div>
@@ -28,6 +28,9 @@ import { commentModelsFromObject } from '@src/view_models/Comment';
 import FunSelect from '@src/components/shared/legacy_form_inputs/FunSelect.vue';
 import { onMounted, ref } from 'vue';
 import { Comment } from '@src/view_models/Comment';
+import { useI18n } from 'vue-i18n';
+
+const { t, n } = useI18n();
 
 const PAGE_SIZE = 10;
 
@@ -58,10 +61,13 @@ const previousPage = () => {
 	}
 };
 
-const headlineVars = ( comment ) => ( {
-	formattedAmount: $n( comment.amount, { key: 'currency' } ),
-	donor: comment.donor,
-} );
+const commentHeadline = ( comment: Comment ) => t(
+	'donation_comments_donor_headline',
+	{
+		formattedAmount: n( Number( comment.amount ), { key: 'currency' } ),
+		donor: comment.donor,
+	}
+);
 
 onMounted( () => {
 	axios


### PR DESCRIPTION
The converted `CommentList` component contained a reference to the number
formatting function `$n` that was not imported. This change moves both
the creation of the translation placeholder (which uses the number
formatting) and the translation into a utility function.
