### PR TITLE
Add new use of funds colours

### DIFF
--- a/src/components/pages/UseOfFunds.vue
+++ b/src/components/pages/UseOfFunds.vue
@@ -8,7 +8,6 @@
 		</div>
 
 		<FundsDistributionAccordion :application-of-funds-data="content.applicationOfFundsData" />
-		<FundsDistributionInfo :application-of-funds-data="content.applicationOfFundsData" />
 
 		<div class="use_of_funds__section">
 			<p class="use_of_funds__info_text" v-html="content.detailedReports.mixed.text"></p>
@@ -93,6 +92,5 @@ export default defineComponent( {
 <style lang="scss">
 @import '../../scss/use_of_funds/FundsContent';
 @import '../../scss/use_of_funds/CompanyBudgets';
-@import'../../scss/use_of_funds/FundsDistributionInfo';
 @import'../../scss/use_of_funds/FundsDistributionAccordion';
 </style>

--- a/src/scss/use_of_funds/FundsDistributionAccordion.scss
+++ b/src/scss/use_of_funds/FundsDistributionAccordion.scss
@@ -4,10 +4,6 @@
 	padding-bottom: 16px;
 	display: block;
 
-	@media (min-width: $use_of_funds_breakpoint_m) {
-		display: none;
-	}
-
 	.funds_distribution_info_item {
 		&__title {
 			font-weight: bold;
@@ -55,7 +51,8 @@
 			display: block;
 		}
 
-		&--software {
+		&--software,
+		&--infrastructure {
 			.funds_distribution_info_item__title {
 				color: #808080;
 			}
@@ -63,6 +60,16 @@
 		&--international {
 			.funds_distribution_info_item__title {
 				color: #0ea789;
+			}
+		}
+		&--diversity {
+			.funds_distribution_info_item__title {
+				color: #e61eb8;
+			}
+		}
+		&--access {
+			.funds_distribution_info_item__title {
+				color: #de8500;
 			}
 		}
 		&--communities {


### PR DESCRIPTION
Use of funds now has 7 items so add new colours
for them.

Also removes the vertical bar chart and displays
the accordion on all sizes.

Ticket: https://phabricator.wikimedia.org/T349927