### PR TITLE
Pass impression counts and tracking in memberships

### DIFF
--- a/src/components/pages/MembershipForm.vue
+++ b/src/components/pages/MembershipForm.vue
@@ -15,7 +15,9 @@
 <script setup lang="ts">
 import { Component, computed, ref, watch } from 'vue';
 import { Country } from '@src/view_models/Country';
+import { CampaignValues } from '@src/view_models/CampaignValues';
 import { AddressValidation } from '@src/view_models/Validation';
+import { TrackingData } from '@src/view_models/TrackingData';
 import { Salutation } from '@src/view_models/Salutation';
 import PaymentPage from '@src/components/pages/membership_form/subpages/PaymentPage.vue';
 import AddressPage from '@src/components/pages/membership_form/subpages/AddressPage.vue';
@@ -34,6 +36,8 @@ interface Props {
 	showMembershipTypeOption: Boolean,
 	addressValidationPatterns: AddressValidation;
 	dateOfBirthValidationPattern: String,
+	campaignValues: CampaignValues;
+	trackingData: TrackingData
 	startPageIndex?: number;
 }
 
@@ -68,6 +72,8 @@ const currentProperties = computed( (): object => {
 			salutations: props.salutations,
 			addressValidationPatterns: props.addressValidationPatterns,
 			dateOfBirthValidationPattern: props.dateOfBirthValidationPattern,
+			trackingData: props.trackingData,
+			campaignValues: props.campaignValues,
 		};
 	}
 	return {

--- a/src/components/pages/membership_form/SubmitValues.vue
+++ b/src/components/pages/membership_form/SubmitValues.vue
@@ -24,6 +24,10 @@
 		<input type="hidden" name="donationReceipt" :value="receipt">
 		<input type="hidden" name="dob" :value="formattedDateOfBirth">
 		<input type="hidden" name="incentives[]" :value="incentives">
+		<input type="hidden" name="impCount" :value="trackingData.impressionCount">
+		<input type="hidden" name="bImpCount" :value="trackingData.bannerImpressionCount">
+		<input type="hidden" name="piwik_campaign" :value="campaignValues.campaign">
+		<input type="hidden" name="piwik_kwd" :value="campaignValues.keyword">
 
 	</span>
 </template>
@@ -37,9 +41,15 @@ import { MembershipAddressState } from '@src/view_models/Address';
 import { addressTypeName } from '@src/view_models/AddressTypeModel';
 import { BankAccount } from '@src/view_models/BankAccount';
 import { membershipTypeName } from '@src/view_models/MembershipTypeModel';
+import { TrackingData } from '@src/view_models/TrackingData';
+import { CampaignValues } from '@src/view_models/CampaignValues';
 
 export default defineComponent( {
 	name: 'SubmitValues',
+	props: {
+		trackingData: Object as () => TrackingData,
+		campaignValues: Object as () => CampaignValues,
+	},
 	computed: {
 		...mapState<Payment>( NS_MEMBERSHIP_FEE, {
 			fee: ( state: Payment ) => state.values,

--- a/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -44,7 +44,7 @@
 		</FormSummary>
 
 		<form action="/apply-for-membership" method="post" ref="submitValuesForm">
-			<SubmitValues/>
+			<SubmitValues :campaign-values="campaignValues" :tracking-data="trackingData"/>
 		</form>
 	</div>
 </template>
@@ -60,6 +60,8 @@ import { Salutation } from '@src/view_models/Salutation';
 import { membershipTypeName } from '@src/view_models/MembershipTypeModel';
 import { addressTypeName } from '@src/view_models/AddressTypeModel';
 import { Country } from '@src/view_models/Country';
+import { CampaignValues } from '@src/view_models/CampaignValues';
+import { TrackingData } from '@src/view_models/TrackingData';
 import { useStore } from 'vuex';
 import { useAddressFormEventHandlers } from '@src/components/pages/membership_form/useAddressFormEventHandlers';
 import { trackFormSubmission } from '@src/util/tracking';
@@ -73,6 +75,8 @@ interface Props {
 	salutations: Salutation[];
 	addressValidationPatterns: AddressValidation;
 	dateOfBirthValidationPattern: String;
+	campaignValues: CampaignValues;
+	trackingData: TrackingData
 }
 
 const props = defineProps<Props>();

--- a/src/pages/membership_application.ts
+++ b/src/pages/membership_application.ts
@@ -28,12 +28,14 @@ import MembershipForm from '@src/components/pages/MembershipForm.vue';
 import App from '@src/components/App.vue';
 import { createFeatureFetcher } from '@src/util/FeatureFetcher';
 import { bucketIdToCssClass } from '@src/util/bucket_id_to_css_class';
+import CampaignParameters from '@src/util/CampaignParameters';
+import { TrackingData } from '@src/view_models/TrackingData';
 
 interface MembershipAmountModel {
 	presetAmounts: Array<string>,
 	paymentIntervals: Array<string>,
 	paymentTypes: Array<string>,
-	tracking: Array<number>,
+	tracking: TrackingData,
 	countries: Array<Country>,
 	salutations: Array<Salutation>,
 	urls: any,
@@ -50,6 +52,7 @@ const pageData = new PageDataInitializer<MembershipAmountModel>( '#appdata' );
 const dataPersister = createDataPersister( new LocalStorageRepository(), FORM_NAMESPACE, pageData.applicationVars.userDataKey );
 const store = createStore( [ dataPersister.getPlugin( persistenceItems ), createTrackFormErrorsPlugin( FORM_NAMESPACE ) ] );
 const featureFetcher = createFeatureFetcher( pageData.selectedBuckets, pageData.activeFeatures );
+const campaignParameters = new CampaignParameters( new URLSearchParams( window.location.search ) );
 
 dataPersister.initialize( persistenceItems ).then( () => {
 
@@ -103,6 +106,8 @@ dataPersister.initialize( persistenceItems ).then( () => {
 				paymentTypes: pageData.applicationVars.paymentTypes,
 				addressValidationPatterns: pageData.applicationVars.addressValidationPatterns,
 				dateOfBirthValidationPattern: pageData.applicationVars.dateOfBirthValidationPattern,
+				trackingData: pageData.applicationVars.tracking,
+				campaignValues: campaignParameters.getCampaignValues(),
 			},
 		} );
 		app.provide( 'cityAutocompleteResource', new ApiCityAutocompleteResource() );

--- a/tests/unit/components/pages/membership_form/SubmitValues.spec.ts
+++ b/tests/unit/components/pages/membership_form/SubmitValues.spec.ts
@@ -58,6 +58,16 @@ describe( 'SubmitValues.vue', () => {
 			global: {
 				plugins: [ store ],
 			},
+			props: {
+				trackingData: {
+					bannerImpressionCount: 1,
+					impressionCount: 5,
+				},
+				campaignValues: {
+					campaign: 'nicholas',
+					keyword: 'cage',
+				},
+			},
 		} );
 	} );
 

--- a/tests/unit/components/pages/membership_form/__snapshots__/SubmitValues.spec.ts.snap
+++ b/tests/unit/components/pages/membership_form/__snapshots__/SubmitValues.spec.ts.snap
@@ -103,5 +103,25 @@ exports[`SubmitValues.vue renders input fields 1`] = `
     type="hidden"
     value=""
   />
+  <input
+    name="impCount"
+    type="hidden"
+    value="5"
+  />
+  <input
+    name="bImpCount"
+    type="hidden"
+    value="1"
+  />
+  <input
+    name="piwik_campaign"
+    type="hidden"
+    value="nicholas"
+  />
+  <input
+    name="piwik_kwd"
+    type="hidden"
+    value="cage"
+  />
 </span>
 `;


### PR DESCRIPTION
Add impression counts and Matomo parameters to the `SubmitValues`
components of the membership form. The impression counts are not
gauarteed to be in the URL, so we read them from `applicationVars`
(provided by https://github.com/wmde/fundraising-application/pull/2898 )

Ticket: https://phabricator.wikimedia.org/T353809
