### PR TITLE
The membership type component is hidden

### DIFF
--- a/src/components/pages/membership_form/subpages/PaymentPage.vue
+++ b/src/components/pages/membership_form/subpages/PaymentPage.vue
@@ -2,9 +2,8 @@
 	<div class="payment-page">
 		<h1 class="title is-size-1">{{ $t('membership_form_headline' ) }}</h1>
 
-		<FormSection :title="$t('membership_form_membershiptype_legend')" title-margin="x-small">
+		<FormSection v-if="showMembershipTypeOption" :title="$t('membership_form_membershiptype_legend')" title-margin="x-small">
 			<MembershipTypeField
-				v-if="showMembershipTypeOption"
 				v-model="membershipTypeModel"
 				:disabledMembershipTypes="disabledMembershipTypes"
 			/>


### PR DESCRIPTION
- When the URL parameter is passed to hide the membership type fields, headline of the component is not displayed

Ticket: https://phabricator.wikimedia.org/T353943