### PR TITLE
Use mailing list in Update address page

### DIFF
--- a/src/components/pages/donation_confirmation/AddressUpdateForm.vue
+++ b/src/components/pages/donation_confirmation/AddressUpdateForm.vue
@@ -113,6 +113,7 @@ import RadioField from '@src/components/shared/form_fields/RadioField.vue';
 import PostalAddressFields from '@src/components/shared/PostalAddressFields.vue';
 import { useAddressTypeFunctions } from '@src/components/pages/donation_form/AddressTypeFunctions';
 import scrollToFirstError from '@src/util/scroll_to_first_error';
+import { MAILING_LIST_ADDRESS_PAGE } from '@src/config';
 
 interface Props {
 	addressValidationPatterns: AddressValidation;
@@ -209,10 +210,7 @@ const { addressType, addressTypeIsInvalid, setAddressType } = useAddressTypeFunc
 const addressTypeModel = ref<AddressTypeModel>( addressType.value );
 watch( addressTypeModel, ( newAddressType: AddressTypeModel ) => setAddressType( newAddressType ) );
 
-// const mailingList = useMailingListModel( store );
-
-// TODO: get default value from somewhere (backend or frontend)
-const mailingList = ref<boolean>( true );
+const mailingList = ref<boolean>( MAILING_LIST_ADDRESS_PAGE );
 
 const validateForm = async (): Promise<ValidationResult> => {
 	let response = await store.dispatch( action( NS_ADDRESS, validateAddressType ), {

--- a/src/components/pages/donation_confirmation/AddressUpdateForm.vue
+++ b/src/components/pages/donation_confirmation/AddressUpdateForm.vue
@@ -112,7 +112,6 @@ import NameFields from '@src/components/shared/NameFields.vue';
 import RadioField from '@src/components/shared/form_fields/RadioField.vue';
 import PostalAddressFields from '@src/components/shared/PostalAddressFields.vue';
 import { useAddressTypeFunctions } from '@src/components/pages/donation_form/AddressTypeFunctions';
-import { useMailingListModel } from '@src/components/shared/form_fields/useMailingListModel';
 import scrollToFirstError from '@src/util/scroll_to_first_error';
 
 interface Props {
@@ -210,7 +209,10 @@ const { addressType, addressTypeIsInvalid, setAddressType } = useAddressTypeFunc
 const addressTypeModel = ref<AddressTypeModel>( addressType.value );
 watch( addressTypeModel, ( newAddressType: AddressTypeModel ) => setAddressType( newAddressType ) );
 
-const mailingList = useMailingListModel( store );
+// const mailingList = useMailingListModel( store );
+
+// TODO: get default value from somewhere (backend or frontend)
+const mailingList = ref<boolean>( true );
 
 const validateForm = async (): Promise<ValidationResult> => {
 	let response = await store.dispatch( action( NS_ADDRESS, validateAddressType ), {
@@ -245,6 +247,7 @@ const getAddressData = (): Address => {
 		updateToken: props.donation.updateToken,
 		donationId: props.donation.id,
 		addressType: addressTypeName( store.getters[ NS_ADDRESS + '/addressType' ] ),
+		mailingList: mailingList.value,
 	} as any;
 	Object.keys( formData ).forEach( fieldName => {
 		data[ fieldName ] = formData[ fieldName ].value;

--- a/src/components/pages/donation_form/AddressForms.vue
+++ b/src/components/pages/donation_form/AddressForms.vue
@@ -148,9 +148,9 @@ import { StoreKey } from '@src/store/donation_store';
 import { injectStrict } from '@src/util/injectStrict';
 import { AddressTypeIds } from '@src/components/pages/donation_form/AddressTypeIds';
 import { Validity } from '@src/view_models/Validity';
-import { useMailingListModel } from '@src/components/shared/form_fields/useMailingListModel';
 import ValueEqualsPlaceholderWarning from '@src/components/shared/ValueEqualsPlaceholderWarning.vue';
 import { useReceiptModel } from '@src/components/pages/donation_form/DonationReceipt/useReceiptModel';
+import { useMailingListModel } from '@src/components/shared/form_fields/useMailingListModel';
 
 interface Props {
 	countries: Country[],

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const MAILING_LIST_ADDRESS_PAGE:boolean = true;

--- a/src/store/dataInitializers.ts
+++ b/src/store/dataInitializers.ts
@@ -9,6 +9,7 @@ import { InitialPaymentValues } from '@src/view_models/Payment';
 import { BankAccountData, InitialBankAccountData } from '@src/view_models/BankAccount';
 import { InitialMembershipFeeValues } from '@src/view_models/MembershipFee';
 import { trackFormFieldRestored } from '@src/util/tracking';
+import { MAILING_LIST_ADDRESS_PAGE } from '@src/config';
 
 const replaceInitialValue = ( defaultValue: any, replacement: any ): any => {
 	if ( replacement !== undefined && replacement !== null && replacement !== '' ) {
@@ -46,7 +47,7 @@ export const createInitialDonationAddressValues = ( dataPersister: DataPersister
 		// The address type chosen by the user in the banner should override the choice made later, assuming that
 		// reloading the page (and restoring from localStorage) happens less often than coming back from a banner
 		addressType: replaceInitialValue( dataPersister.getValue( 'addressType' ), initialFormValues.addressType ),
-		newsletter: replaceInitialValue( null, dataPersister.getValue( 'newsletter' ) ),
+		newsletter: replaceInitialValue( MAILING_LIST_ADDRESS_PAGE, dataPersister.getValue( 'newsletter' ) ),
 		receipt: replaceInitialValue( null, dataPersister.getValue( 'receipt' ) ),
 		fields: addressPersistItems,
 	};


### PR DESCRIPTION
-  Use globally defined 'mailingList' value
- The default value is set to 'true'
- We do not use the store for this
- The globally defined mailingList is for Update Address Page and data initializers
- The purpose of doing this is: In future the 'mailingList' value can be accessed easily (for testing)

Ticket: https://phabricator.wikimedia.org/T344425