### PR TITLE
Make amount field more accessible

### DIFF
--- a/src/components/shared/form_elements/RadioFormInput.vue
+++ b/src/components/shared/form_elements/RadioFormInput.vue
@@ -14,6 +14,8 @@
 			:value="nativeValue"
 			:disabled="disabled"
 			:required="required"
+			:aria-errormessage="ariaErrorMessage"
+			:aria-invalid="ariaInvalid"
 		/>
 		<span class="check"/>
 		<span class="control-label"><slot/></span>
@@ -31,11 +33,15 @@ interface Props {
 	name: string;
 	disabled?: boolean;
 	required?: boolean;
+	ariaErrorMessage?: string
+	ariaInvalid?: boolean
 }
 
 const props = withDefaults( defineProps<Props>(), {
 	disabled: false,
 	required: false,
+	ariaErrorMessage: '',
+	ariaInvalid: false,
 } );
 const emit = defineEmits( [ 'update:modelValue' ] );
 

--- a/src/components/shared/form_elements/TextFormInput.vue
+++ b/src/components/shared/form_elements/TextFormInput.vue
@@ -12,6 +12,8 @@
 			:placeholder="placeholder"
 			:disabled="disabled"
 			:required="required"
+			:aria-errormessage="ariaErrorMessage"
+			:aria-invalid="ariaInvalid"
 			@blur="onBlur"
 			@focus="onFocus"
 		/>
@@ -26,6 +28,8 @@
 			:placeholder="placeholder"
 			:disabled="disabled"
 			:required="required"
+			:aria-errormessage="ariaErrorMessage"
+			:aria-invalid="ariaInvalid"
 			@blur="onBlur"
 			@focus="onFocus"
 		/>
@@ -48,11 +52,13 @@ interface Props {
 	modelValue: string | number;
 	autocomplete?: string;
 	inputId: string;
-	placeholder: String;
+	placeholder: string;
 	hasMessage: boolean;
 	hasError?: boolean;
 	disabled?: boolean;
 	required?: boolean;
+	ariaErrorMessage?: string
+	ariaInvalid?: boolean
 }
 
 const props = withDefaults( defineProps<Props>(), {
@@ -60,6 +66,8 @@ const props = withDefaults( defineProps<Props>(), {
 	hasError: false,
 	disabled: false,
 	required: false,
+	ariaErrorMessage: '',
+	ariaInvalid: false,
 } );
 const emit = defineEmits( [ 'update:modelValue', 'focus', 'blur' ] );
 

--- a/src/components/shared/form_fields/AmountField.vue
+++ b/src/components/shared/form_fields/AmountField.vue
@@ -12,6 +12,8 @@
 					:class="{ 'inactive': paymentAmount < minimumAmount }"
 					:disabled="paymentAmount < minimumAmount"
 					@update:model-value="updateAmountFromRadio"
+						:aria-invalid="showError"
+						:aria-error-message="showError ? 'amount-error' : ''"
 				>
 					{{ $n( paymentAmount / 100, 'euros' ) }}
 				</RadioFormInput>
@@ -30,11 +32,13 @@
 				@blur="setCustomAmount"
 				@focus.prevent="resetErrorInput"
 				@update:model-value="updateAmountFromCustom"
+				:aria-invalid="showError"
+				:aria-error-message="showError ? 'amount-error' : ''"
 			/>
 			<!-- eslint-disable vuejs-accessibility/label-has-for -->
 			<label for="amount-custom" class="is-sr-only">{{ $t('donation_form_payment_amount_legend') }}</label>
 		</div>
-		<span v-if="showError" class="help is-danger">{{ errorMessage }}</span>
+		<span v-if="showError" class="help is-danger" id="amount-error" role="alert">{{ errorMessage }}</span>
 
 		<slot name="info-message"/>
 	</fieldset>


### PR DESCRIPTION
Add aria attributes to RadioFormInput and TextFormInput.

To keep in sync with the HTML ARIA attribute, we're using `ariaDescribedby` and `aria-describedby` instead of the more Vue-like and semantic `ariaDescribedBy` and `aria-described-by`.

Using `aria-described-by` instead of `aria-errormessage`, because some screen readers don't support errormessage.
See https://www.davidmacd.com/blog/test-aria-describedby-errormessage-aria-live.html

Ticket: https://phabricator.wikimedia.org/T361813