### PR TITLE
Fix some eslint a11y issues

### DIFF
--- a/src/components/pages/donation_confirmation/SuccessMessage.vue
+++ b/src/components/pages/donation_confirmation/SuccessMessage.vue
@@ -11,7 +11,13 @@
 			<span class="comment-thanks" v-if="commentLinkIsDisabled">
 				{{ $t( 'donation_comment_popup_thanks' ) }}
 			</span>
-			<a v-else id="comment-link" @click="$emit( 'show-comment-modal' )">
+			<a v-else
+					id="comment-link"
+					role="link"
+					tabindex="0"
+					@click="$emit( 'show-comment-modal' )"
+					@keyup.enter.space="$emit( 'show-comment-modal' )"
+			>
 				{{ $t( 'donation_confirmation_comment_button' ) }}
 			</a>
 		</p>

--- a/src/components/pages/donation_form/subpages/PaymentPage.vue
+++ b/src/components/pages/donation_form/subpages/PaymentPage.vue
@@ -1,11 +1,10 @@
 <template>
+	<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
 	<form
 		name="laika-donation-payment"
 		id="laika-donation-payment"
 		class="payment-page"
 		ref="paymentForm"
-		action="/donation/add"
-		method="post"
 		@keydown.enter.prevent="next()"
 	>
 		<h1 class="form-title" v-html="$t( 'donation_form_section_address_headline' )"/>

--- a/src/components/pages/donation_form/subpages/PaymentPage.vue
+++ b/src/components/pages/donation_form/subpages/PaymentPage.vue
@@ -6,6 +6,7 @@
 		class="payment-page"
 		ref="paymentForm"
 		@keydown.enter.prevent="next()"
+		@submit.prevent="next()"
 	>
 		<h1 class="form-title" v-html="$t( 'donation_form_section_address_headline' )"/>
 
@@ -17,7 +18,8 @@
 
 		<FormButton
 			id="next"
-			@click="next()"
+			button-type="submit"
+			@click.prevent="next()"
 			:is-loading="store.getters.isValidating"
 		>
 			{{ $t( 'donation_form_section_continue' ) }}

--- a/src/components/pages/use_of_funds/FundsDistributionAccordion.vue
+++ b/src/components/pages/use_of_funds/FundsDistributionAccordion.vue
@@ -9,8 +9,11 @@
 		>
 			<div
 				class="funds_distribution_info_item__title"
-				@click="setActive( fundsItem.id )"
+				role="button"
+				tabindex="0"
 				:style="{color: fundsItem.colour}"
+				@keyup.enter.space="setActive( fundsItem.id )"
+				@click="setActive( fundsItem.id )"
 			>
 				{{ fundsItem.title }} {{ fundsItem.percentage }}%
 			</div>

--- a/src/components/shared/LocaleSelector.vue
+++ b/src/components/shared/LocaleSelector.vue
@@ -6,10 +6,20 @@
 		</div>
 
 		<div class="navigation-locale-dropdown">
-			<a v-on:click="setCookie( 'de_DE' )" :class="{ 'active': locale === 'de_DE' }">
+			<a :class="{ 'active': locale === 'de_DE' }"
+					role="link"
+					tabindex="0"
+					@click="setCookie( 'de_DE' )"
+					@keyup.enter.space="setCookie( 'de_DE')"
+			>
 				Deutsch <Checkmark v-if="locale === 'de_DE'"/>
 			</a>
-			<a v-on:click="setCookie( 'en_GB' )" :class="{ 'active': locale === 'en_GB' }">
+			<a :class="{ 'active': locale === 'en_GB' }"
+					role="link"
+					tabindex="0"
+					@click="setCookie( 'en_GB' )"
+					@keyup.enter.space="setCookie( 'en_GB')"
+			>
 				English <Checkmark v-if="locale === 'en_GB'"/>
 			</a>
 		</div>

--- a/src/components/shared/PaymentBankData.vue
+++ b/src/components/shared/PaymentBankData.vue
@@ -2,6 +2,7 @@
 	<fieldset class="payment-bank-data-section">
 		<legend class="title is-size-5">{{ $t( 'donation_form_payment_bankdata_title' ) }}</legend>
 		<div v-bind:class="['form-input', { 'is-invalid': bankDataIsInvalid }]">
+			<!-- eslint-disable vuejs-accessibility/label-has-for -->
 			<label for="iban" class="subtitle">{{ $t( labels.iban ) }}</label>
 			<div class="form-field form-field-text">
 				<div class="control text-form-input">

--- a/src/components/shared/form_fields/AmountField.vue
+++ b/src/components/shared/form_fields/AmountField.vue
@@ -31,7 +31,8 @@
 				@focus.prevent="resetErrorInput"
 				@update:model-value="updateAmountFromCustom"
 			/>
-			<label for="form-field-amount-custom" class="is-sr-only">{{ $t('donation_form_payment_amount_legend') }}</label>
+			<!-- eslint-disable vuejs-accessibility/label-has-for -->
+			<label for="amount-custom" class="is-sr-only">{{ $t('donation_form_payment_amount_legend') }}</label>
 		</div>
 		<span v-if="showError" class="help is-danger">{{ errorMessage }}</span>
 

--- a/src/components/shared/form_fields/CityAutocompleteField.vue
+++ b/src/components/shared/form_fields/CityAutocompleteField.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="form-field form-field-autocomplete" :class="{ 'is-invalid': showError }">
+		<!-- eslint-disable vuejs-accessibility/label-has-for -->
 		<label for="city" class="form-field-label">{{ label }}</label>
 		<div class="form-field-autocomplete-container">
 			<TextFormInput

--- a/src/components/shared/form_fields/CountryAutocompleteField.vue
+++ b/src/components/shared/form_fields/CountryAutocompleteField.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="form-field form-field-autocomplete" :class="{ 'is-invalid': showError }">
+		<!-- eslint-disable vuejs-accessibility/label-has-for -->
 		<label for="country" class="form-field-label">{{ label }}</label>
 		<div class="form-field-autocomplete-container">
 			<TextFormInput
@@ -19,7 +20,7 @@
 					<div class="dropdown-content">
 						<template v-for="( country, index ) in filteredCountries">
 							<span v-if="groupSeparatorIndex === index" class="dropdown-separator"><hr></span>
-							<a class="dropdown-item" role="button" tabindex="0" @click.stop="() => onSelectItem( country )">
+							<a class="dropdown-item" role="button" tabindex="0" @click.stop="() => onSelectItem( country )" @keyup.enter.space="onSelectItem(country)">
 								{{ country.countryFullName }}
 							</a>
 						</template>

--- a/src/components/shared/form_fields/EmailField.vue
+++ b/src/components/shared/form_fields/EmailField.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="form-field form-field-email" :class="{ 'is-invalid': showError }">
+		<!-- eslint-disable vuejs-accessibility/label-has-for -->
 		<label for="email" class="form-field-label">{{ $t( 'donation_form_email_label' ) }}</label>
 		<TextFormInput
 			input-type="text"
@@ -13,7 +14,13 @@
 			@update:modelValue="onUpdateModel"
 			@blur="$emit('field-changed', 'email')"
 		/>
-		<span v-if="suggestedProvider" @click="onSuggestionClicked( suggestedProvider )" class="help is-clickable">
+		<span v-if="suggestedProvider"
+				class="help is-clickable"
+				role="link"
+				tabindex="0"
+				@click="onSuggestionClicked( suggestedProvider )"
+				@keyup.enter.space="onSuggestionClicked( suggestedProvider )"
+		>
 			{{ $t( 'donation_form_email_suggestion' ) }} <strong>{{ suggestedProvider }}</strong>?
 		</span>
 		<span v-if="showError" class="help is-danger error-email">{{ $t( 'donation_form_email_error' ) }}</span>

--- a/src/components/shared/form_fields/SelectField.vue
+++ b/src/components/shared/form_fields/SelectField.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="form-field form-field-select" :class="{ 'is-invalid': showError }">
+		<!-- eslint-disable vuejs-accessibility/label-has-for -->
 		<label :for="name" class="form-field-label">{{ label }}</label>
 		<SelectFormInput
 			v-model="fieldModel"

--- a/src/components/shared/form_fields/TextField.vue
+++ b/src/components/shared/form_fields/TextField.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="form-field" :class="[ `form-field-${inputType}`, { 'is-invalid': showError } ]">
+		<!-- eslint-disable vuejs-accessibility/label-has-for -->
 		<label :for="inputId" class="form-field-label">
 			{{ label }} <em v-if="labelHelpText">{{ labelHelpText }}</em>
 		</label>


### PR DESCRIPTION
The ESLint plugin `eslint-plugin-vuejs-accessibility` marks some
accessibility issues. This commit tackles the issues that won't be
tackled by other, dedicated tickets and pull requests.

We're mostly ignoring the "label" rule inside the files. The files where
we disable it are "false positives" where we're using our own input
components (that aren't recognized as inputs by the rule). In the
future, we might unify the form field components to avoid the A11Y issues
and ensure that IDs and labels do match.

We default on "Enter" and "Space" as the keyboard alternative to "click"
events on non-interactive elements that have a click handler.

We have to disable the `no-static-element-interactions` rule on the
`PaymentForm` component because its keyboard event handler is supposed
to catch the Enter key that bubbles up from other elements.
