### PR TITLE
Make mobile navigation menu accessible

### DIFF
--- a/src/components/layout/NavigationItems.vue
+++ b/src/components/layout/NavigationItems.vue
@@ -1,0 +1,37 @@
+<template>
+	<div
+		id="main-navigation-items"
+		class="navigation-items"
+		:aria-label="$t( 'aria_main_navigation_label' )"
+		:class="{ 'active': showMobileNavbar }"
+		@click="$emit( 'click' )"
+	>
+		<ul>
+			<li v-for="( link, index ) in headerMenu" :key="index">
+				<a
+					:href="link.url"
+					class="navigation-item"
+					:class="{ 'active': link.ids.includes( pageIdentifier ) }"
+					:aria-current="link.ids.includes( pageIdentifier ) ? 'page' : null"
+					@blur="$emit( 'blur' )"
+					@keyup.esc="$emit( 'esc' )"
+				>
+					{{ $t( 'header_menu_item_' + link.localeId ) }}
+				</a>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<script setup lang="ts">
+
+interface Props {
+	showMobileNavbar: boolean;
+	pageIdentifier: string;
+	headerMenu: { ids: string[], url: string, localeId: string }[];
+}
+
+defineProps<Props>();
+defineEmits( [ 'click', 'blur', 'esc' ] );
+
+</script>

--- a/src/components/shared/NavigationBurger.vue
+++ b/src/components/shared/NavigationBurger.vue
@@ -1,15 +1,15 @@
 <template>
-	<a
+	<button
 		class="navigation-burger"
 		:class="{ 'active': active }"
-		role="button"
-		aria-label="menu"
-		aria-expanded="false"
+		aria-controls="main-navigation-items"
+		:aria-label="$t( active ? 'aria_navigation_toggle_label_open' : 'aria_navigation_toggle_label_closed' )"
+		:aria-expanded="active"
 	>
 		<span aria-hidden="true"></span>
 		<span aria-hidden="true"></span>
 		<span aria-hidden="true"></span>
-	</a>
+	</button>
 </template>
 
 <script setup lang="ts">
@@ -30,6 +30,10 @@ defineProps<Props>();
 	width: global.$navbar-height;
 	position: relative;
 	flex-shrink: 0;
+	border: 0;
+	border-radius: 0;
+	background: colors.$white;
+	cursor: pointer;
 
 	&:hover {
 		background: colors.$gray-light;

--- a/src/components/shared/composables/useDisplaySwitch.ts
+++ b/src/components/shared/composables/useDisplaySwitch.ts
@@ -1,0 +1,20 @@
+import { onMounted, onUnmounted, Ref, ref } from 'vue';
+
+export function useDisplaySwitch( minWidthForLargeScreen: number ): Ref<boolean> {
+
+	const showComponentForLargeScreen = ref<boolean>( window.innerWidth > minWidthForLargeScreen );
+
+	const onDisplaySwitchResize = (): void => {
+		showComponentForLargeScreen.value = window.innerWidth > minWidthForLargeScreen;
+	};
+
+	onMounted( () => {
+		window.addEventListener( 'resize', onDisplaySwitchResize );
+	} );
+
+	onUnmounted( () => {
+		window.removeEventListener( 'resize', onDisplaySwitchResize );
+	} );
+
+	return showComponentForLargeScreen;
+}

--- a/tests/unit/components/layout/AppHeader.spec.ts
+++ b/tests/unit/components/layout/AppHeader.spec.ts
@@ -1,17 +1,11 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount, VueWrapper } from '@vue/test-utils';
 import AppHeader from '@src/components/layout/AppHeader.vue';
 import { QUERY_STRING_INJECTION_KEY } from '@src/util/createCampaignQueryString';
 
 describe( 'AppHeader.vue', () => {
-	it.each( [
-		[ 'donation-form', 1 ],
-		[ 'donation-confirmation', 1 ],
-		[ 'membership-application', 2 ],
-		[ 'membership-application-confirmation', 2 ],
-		[ 'use-of-funds', 3 ],
-		[ 'faq-page', 4 ],
-	] )( 'highlights the correct navigation items', ( pageIdentifier: string, navItemIndex: number ) => {
-		const wrapper = shallowMount( AppHeader, {
+
+	const getWrapper = ( pageIdentifier: string = '' ): VueWrapper<any> => {
+		return mount( AppHeader, {
 			props: {
 				assetsPath: '',
 				pageIdentifier,
@@ -22,9 +16,108 @@ describe( 'AppHeader.vue', () => {
 				},
 			},
 		} );
+	};
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it.each( [
+		[ 'donation-form', 1 ],
+		[ 'donation-confirmation', 1 ],
+		[ 'membership-application', 2 ],
+		[ 'membership-application-confirmation', 2 ],
+		[ 'use-of-funds', 3 ],
+		[ 'faq-page', 4 ],
+	] )( 'highlights the correct navigation items', ( pageIdentifier: string, navItemIndex: number ) => {
+		const wrapper = getWrapper( pageIdentifier );
 
 		const link = wrapper.find( '.navigation-items li:nth-child(' + navItemIndex + ') .navigation-item' );
 		expect( link.classes() ).toContain( 'active' );
 		expect( link.attributes( 'aria-current' ) ).toStrictEqual( 'page' );
+	} );
+
+	it( 'hides the menu when keyup escape happens on the burger', async () => {
+		const wrapper = getWrapper();
+		const navigation = wrapper.find( '.navigation-items' );
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+		await wrapper.find( '.navigation-burger' ).trigger( 'keyup.esc' );
+
+		expect( navigation.classes() ).not.toContain( 'active' );
+	} );
+
+	it( 'hides the menu when keyup escape happens on a menu item', async () => {
+		const wrapper = getWrapper();
+		const navigation = wrapper.find( '.navigation-items' );
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+		await wrapper.find( '.navigation-items .navigation-item:nth-child(1)' ).trigger( 'keyup.esc' );
+
+		expect( navigation.classes() ).not.toContain( 'active' );
+	} );
+
+	it( 'toggles the menu when the burger is clicked', async () => {
+		const wrapper = getWrapper();
+		const navigation = wrapper.find( '.navigation-items' );
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+
+		expect( navigation.classes() ).toContain( 'active' );
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+
+		expect( navigation.classes() ).not.toContain( 'active' );
+	} );
+
+	it( 'hides the menu when the burger is blurred and no menu item is focused', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+		await wrapper.find( '.navigation-burger' ).trigger( 'blur' );
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.find( '.navigation-items' ).classes() ).not.toContain( 'active' );
+	} );
+
+	it( 'hides the menu when a menu item is blurred and no menu item is focused', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+		await wrapper.find( '.navigation-items .navigation-item:nth-child(1)' ).trigger( 'blur' );
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.find( '.navigation-items' ).classes() ).not.toContain( 'active' );
+	} );
+
+	it( 'does not hide the menu when the an item is blurred and a different menu item is focused', async () => {
+		const wrapper = getWrapper();
+		const contains = jest.fn().mockReturnValue( true );
+		Object.defineProperty( document, 'activeElement', { value: { classList: { contains } } } );
+
+		await wrapper.find( '.navigation-burger' ).trigger( 'click' );
+		await wrapper.find( '.navigation-burger' ).trigger( 'blur' );
+		await wrapper.find( '.navigation-items .navigation-item:nth-child(1)' ).trigger( 'blur' );
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.find( '.navigation-items' ).classes() ).toContain( 'active' );
+	} );
+
+	it( 'shows the navigation menu in the correct place on large screens', async () => {
+		Object.defineProperty( window, 'innerWidth', { value: 770 } );
+		const wrapper = getWrapper();
+
+		expect( wrapper.find( '.navigation > :nth-child(2)' ).classes() ).toContain( 'navigation-items' );
+	} );
+
+	it( 'shows the navigation menu in the correct place on small screens', async () => {
+		Object.defineProperty( window, 'innerWidth', { value: 769 } );
+		const wrapper = getWrapper();
+
+		expect( wrapper.find( '.navigation > :nth-child(3)' ).classes() ).toContain( 'navigation-items' );
 	} );
 } );


### PR DESCRIPTION
- Move the menu to after the burger
- Use order to put it in the correct spot on desktop
- Hide the menu when focus moves elsewhere
- Hide the menu when the donor hits esc

Ticket: https://phabricator.wikimedia.org/T361782