### PR TITLE
Stop labels being read out multiple times

### DIFF
--- a/src/components/pages/Contact.vue
+++ b/src/components/pages/Contact.vue
@@ -50,6 +50,7 @@
 
 				<SelectField
 					v-model="formData.topic.value"
+					input-id="topic"
 					name="category"
 					:label="$t( 'contact_form_topic_placeholder' )"
 					:options="[

--- a/src/components/pages/donation_confirmation/AddressUpdateForm.vue
+++ b/src/components/pages/donation_confirmation/AddressUpdateForm.vue
@@ -4,15 +4,18 @@
 
 			<RadioField
 				name="addressType"
+				input-id="addressType"
 				class="address-type-field"
 				:options="[
 					{
 						value: AddressTypeModel.PERSON,
 						label: $t( 'donation_form_addresstype_option_private_addresstype_basic' ),
+						id: 'addressType-0',
 					},
 					{
 						value: AddressTypeModel.COMPANY,
 						label: $t( 'donation_form_addresstype_option_company_addresstype_basic' ),
+						id: 'addressType-1',
 					}
 				]"
 				:label="$t( 'donation_form_address_choice_title_addresstype_basic' )"
@@ -55,7 +58,7 @@
 
 		</AutofillHandler>
 
-		<MailingListField v-model="mailingList"/>
+		<MailingListField v-model="mailingList" input-id="newsletter"/>
 
 		<FormSummary :show-border="false">
 			<template #summary-buttons>
@@ -126,7 +129,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const emit = defineEmits( [ 'address-updated' ] );
+const emit = defineEmits( [ 'address-updated', 'close' ] );
 const store = useStore();
 
 const addressForm = ref<HTMLFormElement>( null );

--- a/src/components/pages/donation_form/AddressForms.vue
+++ b/src/components/pages/donation_form/AddressForms.vue
@@ -12,6 +12,7 @@
 					:form-data="formData"
 					:address-type="AddressTypeModel.PERSON"
 					:salutations="salutations"
+					field-id-namespace="person"
 					v-on:field-changed="onFieldChange"
 				/>
 				<PostalAddressFields
@@ -20,6 +21,7 @@
 					:countries="countries"
 					:post-code-validation="addressValidationPatterns.postcode"
 					:country-was-restored="countryWasRestored"
+					field-id-namespace="person"
 					v-on:field-changed="onFieldChange"
 				/>
 				<div class="form-field form-field-donation-receipt">
@@ -34,6 +36,7 @@
 				<EmailField
 					:show-error="fieldErrors.email"
 					v-model="formData.email.value"
+					input-id="person-email"
 					@field-changed="onFieldChange"
 				>
 					<template #message>
@@ -44,7 +47,7 @@
 						/>
 					</template>
 				</EmailField>
-				<MailingListField v-model="mailingList"/>
+				<MailingListField v-model="mailingList" input-id="person-newsletter"/>
 			</AutofillHandler>
 		</form>
 
@@ -60,6 +63,7 @@
 					:form-data="formData"
 					:address-type="AddressTypeModel.COMPANY"
 					:salutations="salutations"
+					field-id-namespace="company"
 					v-on:field-changed="onFieldChange"
 				/>
 				<PostalAddressFields
@@ -68,6 +72,7 @@
 					:countries="countries"
 					:post-code-validation="addressValidationPatterns.postcode"
 					:country-was-restored="countryWasRestored"
+					field-id-namespace="company"
 					v-on:field-changed="onFieldChange"
 				/>
 				<div class="form-field form-field-donation-receipt">
@@ -81,6 +86,7 @@
 				<EmailField
 					:show-error="fieldErrors.email"
 					v-model="formData.email.value"
+					input-id="company-email"
 					@field-changed="onFieldChange"
 				>
 					<template #message>
@@ -91,7 +97,7 @@
 						/>
 					</template>
 				</EmailField>
-				<MailingListField v-model="mailingList"/>
+				<MailingListField v-model="mailingList" input-id="company-newsletter"/>
 			</AutofillHandler>
 		</form>
 
@@ -107,11 +113,13 @@
 					:form-data="formData"
 					:address-type="AddressTypeModel.PERSON"
 					:salutations="salutations"
+					field-id-namespace="email"
 					v-on:field-changed="onFieldChange"
 				/>
 				<EmailField
 					:show-error="fieldErrors.email"
 					v-model="formData.email.value"
+					input-id="email-email"
 					@field-changed="onFieldChange"
 				>
 					<template #message>
@@ -122,7 +130,7 @@
 						/>
 					</template>
 				</EmailField>
-				<MailingListField v-model="mailingList"/>
+				<MailingListField v-model="mailingList" input-id="email-newsletter"/>
 			</AutofillHandler>
 		</form>
 

--- a/src/components/pages/donation_form/AddressTypeBasic.vue
+++ b/src/components/pages/donation_form/AddressTypeBasic.vue
@@ -2,18 +2,22 @@
 
 	<RadioField
 		name="addressType"
+		input-id="addressType"
 		:options="[
 			{
 				value: AddressTypeModel.PERSON,
 				label: $t( 'donation_form_addresstype_option_private_addresstype_basic' ),
+				id: 'addressType-0'
 			},
 			{
 				value: AddressTypeModel.COMPANY,
 				label: $t( 'donation_form_addresstype_option_company_addresstype_basic' ),
+				id: 'addressType-1'
 			},
 			{
 				value: AddressTypeModel.ANON,
 				label: $t( 'donation_form_addresstype_option_anonymous_addresstype_basic' ),
+				id: 'addressType-2'
 			},
 		]"
 		:label="$t( 'donation_form_address_choice_title_addresstype_basic' )"

--- a/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
@@ -5,8 +5,8 @@
 			v-model="addressType"
 			name="addressTypeSelector"
 			:options="[
-				{ value: AddressTypeModel.PERSON, label: $t( 'C23_WMDE_Desktop_DE_05_contact_details_private' ) },
-				{ value: AddressTypeModel.COMPANY_WITH_CONTACT, label: $t( 'C23_WMDE_Desktop_DE_05_contact_details_company' ) },
+				{ value: AddressTypeModel.PERSON, label: $t( 'C23_WMDE_Desktop_DE_05_contact_details_private' ), id: 'addressTypeSelector-0' },
+				{ value: AddressTypeModel.COMPANY_WITH_CONTACT, label: $t( 'C23_WMDE_Desktop_DE_05_contact_details_company' ), id: 'addressTypeSelector-1' },
 			]"
 			:label="$t( 'C23_WMDE_Desktop_DE_05_contact_details_label' )"
 			:show-error="showAddressTypeError"
@@ -66,6 +66,7 @@
 
 		<CityAutocompleteField
 			v-model="formData.city.value"
+			input-id="city"
 			:show-error="showError.city"
 			:label="$t( 'donation_form_city_label' )"
 			:error-message="$t( 'donation_form_city_error' )"
@@ -82,6 +83,7 @@
 
 		<CountryAutocompleteField
 			v-model="formData.country.value"
+			input-id="country"
 			:countries="countries"
 			:was-restored="countryWasRestored"
 			:show-error="showError.country"

--- a/src/components/pages/donation_form/DonationReceipt/NameFields.vue
+++ b/src/components/pages/donation_form/DonationReceipt/NameFields.vue
@@ -5,7 +5,7 @@
 			name="salutation"
 			v-model="formData.salutation.value"
 			:label="$t( 'donation_form_salutation_label' )"
-			:options="salutations"
+			:options="salutationFormOptions"
 			:show-error="showError.salutation"
 			:error-message="$t( 'donation_form_salutation_error' )"
 			@field-changed="$emit('field-changed', 'salutation')"
@@ -15,6 +15,7 @@
 		<SelectField
 			name="title"
 			v-model="formData.title.value"
+			input-id="title"
 			:label="$t( 'donation_form_academic_title_label' )"
 			:options="[
 				{ label: $t( 'donation_form_academic_title_option_none' ), value: '' },
@@ -67,6 +68,7 @@ import ValueEqualsPlaceholderWarning from '@src/components/shared/ValueEqualsPla
 import RadioField from '@src/components/shared/form_fields/RadioField.vue';
 import SelectField from '@src/components/shared/form_fields/SelectField.vue';
 import TextField from '@src/components/shared/form_fields/TextField.vue';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 
 interface Props {
 	salutations: Salutation[];
@@ -74,7 +76,11 @@ interface Props {
 	showError: AddressValidity;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 defineEmits( [ 'field-changed' ] );
+
+const salutationFormOptions: CheckboxFormOption[] = props.salutations.map( ( x, index ) => (
+	{ value: x.value, label: x.label, id: `salutation-${ index }` }
+) );
 
 </script>

--- a/src/components/pages/donation_form/Payment.vue
+++ b/src/components/pages/donation_form/Payment.vue
@@ -13,6 +13,7 @@
 		<FormSection>
 			<RadioField
 				name="interval"
+				input-id="interval"
 				v-model="interval"
 				:label="$t('donation_form_payment_interval_title')"
 				:options="paymentIntervalsAsOptions"
@@ -25,6 +26,7 @@
 		<FormSection>
 			<RadioField
 				name="paymentType"
+				input-id="paymentType"
 				v-model="paymentType"
 				:label="$t('donation_form_payment_type_title')"
 				:options="paymentTypesAsOptions"
@@ -59,7 +61,7 @@ import { AmountValidity } from '@src/view_models/Payment';
 import { useI18n } from 'vue-i18n';
 import AmountField from '@src/components/shared/form_fields/AmountField.vue';
 import RadioField from '@src/components/shared/form_fields/RadioField.vue';
-import { FormOption } from '@src/components/shared/form_fields/FormOption';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 import { usePaymentFieldModel } from '@src/components/pages/donation_form/usePaymentFieldModel';
 import { Validity } from '@src/view_models/Validity';
 import FormSection from '@src/components/shared/form_elements/FormSection.vue';
@@ -80,16 +82,16 @@ const interval = usePaymentFieldModel( store, 'interval', setInterval );
 const paymentType = usePaymentFieldModel( store, 'type', setType );
 const paymentTypeIsValid = computed<boolean>( () => store.state[ NS_PAYMENT ].validity.type !== Validity.INVALID );
 
-const paymentIntervalsAsOptions = computed<FormOption[]>( () => {
+const paymentIntervalsAsOptions = computed<CheckboxFormOption[]>( () => {
 	return props.paymentIntervals.map(
-		( intervalValue: number ) => (
-			{ value: intervalValue.toString(), label: t( 'donation_form_payment_interval_' + intervalValue ) }
+		( intervalValue: number, index: number ) => (
+			{ value: intervalValue.toString(), label: t( 'donation_form_payment_interval_' + intervalValue ), id: `interval-${ index }` }
 		) );
 } );
 
-const paymentTypesAsOptions = computed<FormOption[]>( () => {
+const paymentTypesAsOptions = computed<CheckboxFormOption[]>( () => {
 	return props.paymentTypes.map(
-		( paymentTypeValue: string ) => ( { value: paymentTypeValue, label: t( paymentTypeValue ) } )
+		( paymentTypeValue: string, index: number ) => ( { value: paymentTypeValue, label: t( paymentTypeValue ), id: `paymentType-${ index }` } )
 	);
 } );
 

--- a/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
+++ b/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
@@ -40,14 +40,14 @@
 					</template>
 				</EmailField>
 
-				<MailingListField v-model="mailingList"/>
+				<MailingListField v-model="mailingList" input-id="newsletter"/>
 
 				<RadioField
 					v-model="receiptNeeded"
 					name="donationReceipt"
 					:options="[
-						{ value: true, label: $t( 'yes' ) },
-						{ value: false, label: $t( 'no' ) },
+						{ value: true, label: $t( 'yes' ), id: 'donationReceipt-0' },
+						{ value: false, label: $t( 'no' ), id: 'donationReceipt-1' },
 					]"
 					:label="$t( 'donation_confirmation_cta_title_alt' )"
 					:show-error="showReceiptOptionError"

--- a/src/components/pages/membership_form/Address.vue
+++ b/src/components/pages/membership_form/Address.vue
@@ -87,7 +87,7 @@ import CheckboxSingleFormInput from '@src/components/shared/form_elements/Checkb
 import TextField from '@src/components/shared/form_fields/TextField.vue';
 import { useReceiptModel } from '@src/components/pages/membership_form/useReceiptModel';
 import { useIncentivesModel } from '@src/components/pages/membership_form/useIncentivesModel';
-import { FormOption } from '@src/components/shared/form_fields/FormOption';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 import { useI18n } from 'vue-i18n';
 import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
 
@@ -121,9 +121,8 @@ const {
 	dateOfBirthValidationPattern: props.dateOfBirthValidationPattern.toString(),
 }, store );
 
-const incentivesAsOptions : FormOption[] = [
+const incentivesAsOptions : CheckboxFormOption[] = [
 	{ value: 'tote_bag', label: t( 'membership_form_incentive' ), id: 'tote_bag' },
-
 ];
 
 const addressTypeFromStore = computed( (): AddressTypeModel => {

--- a/src/components/pages/membership_form/AddressType.vue
+++ b/src/components/pages/membership_form/AddressType.vue
@@ -5,10 +5,12 @@
 			{
 				value: AddressTypeModel.PERSON,
 				label: $t( 'donation_form_addresstype_option_private' ),
+				id: 'addressType-0',
 			},
 			{
 				value: AddressTypeModel.COMPANY,
 				label: $t( 'donation_form_addresstype_option_company' ),
+				id: 'addressType-1',
 			},
 		]"
 		:disabled="disabledAddressTypes"

--- a/src/components/pages/membership_form/MembershipTypeField.vue
+++ b/src/components/pages/membership_form/MembershipTypeField.vue
@@ -5,10 +5,12 @@
 			{
 				value: MembershipTypeModel.SUSTAINING,
 				label: $t( 'membership_form_membershiptype_option_sustaining' ),
+				id: 'membershipType-0',
 			},
 			{
 				value: MembershipTypeModel.ACTIVE,
 				label: $t( 'membership_form_membershiptype_option_active' ),
+				id: 'membershipType-1',
 			},
 		]"
 		v-model="fieldModel"

--- a/src/components/pages/membership_form/Payment.vue
+++ b/src/components/pages/membership_form/Payment.vue
@@ -59,7 +59,7 @@ import { useI18n } from 'vue-i18n';
 import { usePaymentFieldModel } from '@src/components/pages/membership_form/usePaymentFieldModel';
 import RadioField from '@src/components/shared/form_fields/RadioField.vue';
 import FormSection from '@src/components/shared/form_elements/FormSection.vue';
-import { FormOption } from '@src/components/shared/form_fields/FormOption';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 import { NS_MEMBERSHIP_ADDRESS, NS_MEMBERSHIP_FEE } from '@src/store/namespaces';
 import PaymentBankData from '@src/components/shared/PaymentBankData.vue';
 import AmountField from '@src/components/shared/form_fields/AmountField.vue';
@@ -96,17 +96,17 @@ const getAmountTitle = computed( () => {
 	return t( `membership_form_payment_amount_title_interval_${interval.value}` );
 } );
 
-const paymentIntervalsAsOptions = computed<FormOption[]>( () => {
+const paymentIntervalsAsOptions = computed<CheckboxFormOption[]>( () => {
 	return props.paymentIntervals.map(
-		( intervalValue: number ) => (
-			{ value: intervalValue.toString(), label: t( 'donation_form_payment_interval_' + intervalValue ) }
+		( intervalValue: number, index: number ) => (
+			{ value: intervalValue.toString(), label: t( 'donation_form_payment_interval_' + intervalValue ), id: `interval-${ index }` }
 		) );
 } );
 
-const paymentTypesAsOptions = computed<FormOption[]>( () => {
+const paymentTypesAsOptions = computed<CheckboxFormOption[]>( () => {
 	return props.paymentTypes.map(
-		( paymentTypeValue: string ) => (
-			{ value: paymentTypeValue, label: t( paymentTypeValue ) }
+		( paymentTypeValue: string, index: number ) => (
+			{ value: paymentTypeValue, label: t( paymentTypeValue ), id: `paymentType-${ index }` }
 		) );
 } );
 

--- a/src/components/shared/NameFields.vue
+++ b/src/components/shared/NameFields.vue
@@ -6,7 +6,7 @@
 			name="salutation"
 			v-model="formData.salutation.value"
 			:label="$t( 'donation_form_salutation_label' )"
-			:options="salutations"
+			:options="salutationFormOptions"
 			:show-error="showError.salutation"
 			:error-message="$t( 'donation_form_salutation_error' )"
 			@field-changed="$emit('field-changed', 'salutation')"
@@ -16,6 +16,7 @@
 		<SelectField
 			v-if="showPersonalFields"
 			name="title"
+			:input-id="`${fieldIdNamespace}title`"
 			v-model="formData.title.value"
 			:label="$t( 'donation_form_academic_title_label' )"
 			:options="[
@@ -30,7 +31,7 @@
 		<TextField
 			v-if="showPersonalFields"
 			name="firstName"
-			input-id="first-name"
+			:input-id="`${fieldIdNamespace}first-name`"
 			v-model="formData.firstName.value"
 			:show-error="showError.firstName"
 			:error-message="$t( 'donation_form_firstname_error' )"
@@ -43,7 +44,7 @@
 		<TextField
 			v-if="showPersonalFields"
 			name="lastName"
-			input-id="last-name"
+			:input-id="`${fieldIdNamespace}last-name`"
 			v-model="formData.lastName.value"
 			:show-error="showError.lastName"
 			:error-message="$t( 'donation_form_lastname_error' )"
@@ -64,7 +65,7 @@
 		<TextField
 			v-if="showCompanyFields"
 			name="companyName"
-			input-id="company-name"
+			:input-id="`${fieldIdNamespace}company-name`"
 			v-model="formData.companyName.value"
 			:show-error="showError.companyName"
 			:error-message="$t( 'donation_form_companyname_error' )"
@@ -86,12 +87,14 @@ import SelectField from '@src/components/shared/form_fields/SelectField.vue';
 import TextField from '@src/components/shared/form_fields/TextField.vue';
 import { computed } from 'vue';
 import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 
 interface Props {
 	addressType: AddressTypeModel
 	salutations: Salutation[];
 	formData: AddressFormData;
 	showError: AddressValidity;
+	fieldIdNamespace?: string;
 }
 
 const props = defineProps<Props>();
@@ -105,5 +108,9 @@ const showPersonalFields = computed( () =>
 	].includes( props.addressType )
 );
 const showCompanyFields = computed( () => props.addressType === AddressTypeModel.COMPANY );
+const fieldIdNamespace = props.fieldIdNamespace ? `${props.fieldIdNamespace}-` : '';
+const salutationFormOptions: CheckboxFormOption[] = props.salutations.map( ( x, index ) => (
+	{ value: x.value, label: x.label, id: `${ fieldIdNamespace }salutation-${ index }` }
+) );
 
 </script>

--- a/src/components/shared/PostalAddressFields.vue
+++ b/src/components/shared/PostalAddressFields.vue
@@ -3,7 +3,7 @@
 
 		<TextField
 			name="street"
-			input-id="street"
+			:input-id="`${fieldIdNamespace}street`"
 			v-model="formData.street.value"
 			:show-error="showError.street"
 			:error-message="$t('donation_form_street_error')"
@@ -27,7 +27,7 @@
 
 		<TextField
 			name="postcode"
-			input-id="post-code"
+			:input-id="`${fieldIdNamespace}post-code`"
 			v-model="formData.postcode.value"
 			:show-error="showError.postcode"
 			:error-message="$t('donation_form_zip_error')"
@@ -47,6 +47,7 @@
 
 		<CityAutocompleteField
 			v-model="formData.city.value"
+			:input-id="`${fieldIdNamespace}city`"
 			:show-error="showError.city"
 			:label="$t( 'donation_form_city_label' )"
 			:error-message="$t( 'donation_form_city_error' )"
@@ -65,6 +66,7 @@
 
 		<CountryAutocompleteField
 			v-model="formData.country.value"
+			:input-id="`${fieldIdNamespace}country`"
 			:countries="countries"
 			:was-restored="countryWasRestored"
 			:show-error="showError.country"
@@ -93,12 +95,14 @@ interface Props {
 	countries: Country[];
 	postCodeValidation: string;
 	countryWasRestored: boolean;
+	fieldIdNamespace?: string;
 }
 
 const props = defineProps<Props>();
 const emit = defineEmits( [ 'field-changed' ] );
 
 const showStreetWarning = computed<boolean>( () => /^\D+$/.test( props.formData.street.value ) );
+const fieldIdNamespace = props.fieldIdNamespace ? `${props.fieldIdNamespace}-` : '';
 
 const onCountryFieldChanged = ( country: Country | undefined ) => {
 	if ( country ) {

--- a/src/components/shared/form_fields/CityAutocompleteField.vue
+++ b/src/components/shared/form_fields/CityAutocompleteField.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="form-field form-field-autocomplete" :class="{ 'is-invalid': showError }">
-		<label for="city" class="form-field-label">{{ label }}</label>
+		<label :for="inputId" class="form-field-label">{{ label }}</label>
 		<div class="form-field-autocomplete-container">
 			<TextFormInput
 				v-model="city"
@@ -9,7 +9,7 @@
 				:placeholder="$t( placeholder, { example: $t( examplePlaceholder ) } )"
 				:has-error="showError"
 				:has-message="false"
-				input-id="city"
+				:input-id="inputId"
 				@focus="onFocus"
 				@blur="onBlur"
 			/>
@@ -39,6 +39,7 @@ import TextFormInput from '@src/components/shared/form_elements/TextFormInput.vu
 
 interface Props {
 	modelValue: string;
+	inputId: string;
 	label: String;
 	examplePlaceholder: string;
 	showError: boolean;

--- a/src/components/shared/form_fields/CountryAutocompleteField.vue
+++ b/src/components/shared/form_fields/CountryAutocompleteField.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="form-field form-field-autocomplete" :class="{ 'is-invalid': showError }">
-		<label for="country" class="form-field-label">{{ label }}</label>
+		<label :for="inputId" class="form-field-label">{{ label }}</label>
 		<div class="form-field-autocomplete-container">
 			<TextFormInput
 				v-model="countryName"
@@ -8,7 +8,7 @@
 				:placeholder="placeholder"
 				:has-error="showError"
 				:has-message="false"
-				input-id="country"
+				:input-id="inputId"
 				name="countrySelector"
 				@focus="onFocus"
 				@blur="() => onBlur( country )"
@@ -42,6 +42,7 @@ import { useCountryAutocompleteEvents } from '@src/components/shared/form_fields
 
 interface Props {
 	modelValue: string;
+	inputId: string;
 	label: String;
 	placeholder: String;
 	countries?: Array<Country>;

--- a/src/components/shared/form_fields/EmailField.vue
+++ b/src/components/shared/form_fields/EmailField.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="form-field form-field-email" :class="{ 'is-invalid': showError }">
-		<label for="email" class="form-field-label">{{ $t( 'donation_form_email_label' ) }}</label>
+		<label :for="inputId ?? 'email'" class="form-field-label">{{ $t( 'donation_form_email_label' ) }}</label>
 		<TextFormInput
 			input-type="text"
-			input-id="email"
+			:input-id="inputId ?? 'email'"
 			name="email"
 			:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_email_placeholder' ) } )"
 			autocomplete="email"
@@ -36,6 +36,7 @@ import TextFormInput from '@src/components/shared/form_elements/TextFormInput.vu
 interface Props {
 	modelValue: string;
 	showError: boolean;
+	inputId?: string;
 }
 
 const props = defineProps<Props>();

--- a/src/components/shared/form_fields/FormOption.ts
+++ b/src/components/shared/form_fields/FormOption.ts
@@ -1,5 +1,0 @@
-export interface FormOption {
-	value: string | number | boolean;
-	label: string;
-	id: string;
-}

--- a/src/components/shared/form_fields/FormOptions.ts
+++ b/src/components/shared/form_fields/FormOptions.ts
@@ -1,0 +1,10 @@
+export interface CheckboxFormOption {
+	value: string | number | boolean;
+	label: string;
+	id: string;
+}
+
+export interface SelectFormOption {
+	value: string | number | boolean;
+	label: string;
+}

--- a/src/components/shared/form_fields/IncentivesField.vue
+++ b/src/components/shared/form_fields/IncentivesField.vue
@@ -5,6 +5,7 @@
 				v-for="incentive in incentiveFormFieldOptions"
 				:native-value="incentive.value"
 				name="incentives"
+				input-id="incentives"
 				v-model="fieldModel"
 				@update:modelValue="onUpdateModel"
 				:input-id="incentive.id"
@@ -19,10 +20,10 @@
 
 import { useFieldModel } from '@src/components/shared/form_fields/useFieldModel';
 import CheckboxMultipleFormInput from '@src/components/shared/form_elements/CheckboxMultipleFormInput.vue';
-import { FormOption } from '@src/components/shared/form_fields/FormOption';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 
 interface Props {
-	incentiveFormFieldOptions: FormOption[];
+	incentiveFormFieldOptions: CheckboxFormOption[];
 	modelValue: string[];
 }
 

--- a/src/components/shared/form_fields/MailingListField.vue
+++ b/src/components/shared/form_fields/MailingListField.vue
@@ -3,7 +3,7 @@
 		<CheckboxSingleFormInput
 			v-model="fieldModel"
 			name="info"
-			input-id="newsletter"
+			:input-id="inputId"
 			@update:modelValue="onUpdateModel"
 			described-by="mailing-list-hint"
 		>
@@ -27,6 +27,7 @@ import { QUERY_STRING_INJECTION_KEY } from '@src/util/createCampaignQueryString'
 
 interface Props {
 	modelValue: boolean;
+	inputId: string;
 }
 
 const props = defineProps<Props>();

--- a/src/components/shared/form_fields/RadioField.vue
+++ b/src/components/shared/form_fields/RadioField.vue
@@ -7,7 +7,7 @@
 				v-for="( option, index ) in options"
 				:key="index"
 				input-type="radio"
-				:id="`${name}-${option.value}`"
+				:id="option.id"
 				:name="name"
 				:disabled="disabled.includes( option.value )"
 				:required="required"
@@ -26,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-import { FormOption } from '@src/components/shared/form_fields/FormOption';
+import { CheckboxFormOption } from '@src/components/shared/form_fields/FormOptions';
 import RadioFormInput from '@src/components/shared/form_elements/RadioFormInput.vue';
 import { useFieldModel } from '@src/components/shared/form_fields/useFieldModel';
 
@@ -34,7 +34,7 @@ interface Props {
 	label?: String;
 	name: string;
 	modelValue: string | number | boolean | null;
-	options: FormOption[];
+	options: CheckboxFormOption[];
 	disabled?: Array<string | number | boolean>;
 	required?: boolean;
 	showError?: boolean;

--- a/src/components/shared/form_fields/SelectField.vue
+++ b/src/components/shared/form_fields/SelectField.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="form-field form-field-select" :class="{ 'is-invalid': showError }">
-		<label :for="name" class="form-field-label">{{ label }}</label>
+		<label :for="inputId" class="form-field-label">{{ label }}</label>
 		<SelectFormInput
 			v-model="fieldModel"
-			:select-id="name"
+			:select-id="inputId"
 			:name="name"
 			:has-error="showError"
 			@update:modelValue="onFieldChange"
@@ -18,15 +18,16 @@
 
 <script setup lang="ts">
 
-import { FormOption } from '@src/components/shared/form_fields/FormOption';
+import { SelectFormOption } from '@src/components/shared/form_fields/FormOptions';
 import { useFieldModel } from '@src/components/shared/form_fields/useFieldModel';
 import SelectFormInput from '@src/components/shared/form_elements/SelectFormInput.vue';
 
 interface Props {
 	label: String;
 	name: string;
+	inputId: string;
 	modelValue: string|number;
-	options: FormOption[];
+	options: SelectFormOption[];
 	errorMessage?: String;
 	showError?: boolean;
 }

--- a/tests/unit/components/pages/donation_form/AddressForms.spec.ts
+++ b/tests/unit/components/pages/donation_form/AddressForms.spec.ts
@@ -103,7 +103,7 @@ describe( 'AddressForms.vue', () => {
 		store.dispatch = jest.fn();
 		const expectedAction = action( NS_ADDRESS, setAddressField );
 		const firstNameValue = 'Vuetiful';
-		await wrapper.find( '#first-name' ).setValue( firstNameValue );
+		await wrapper.find( '#person-first-name' ).setValue( firstNameValue );
 
 		wrapper.findComponent( NameFields ).vm.$emit( 'field-changed', 'firstName' );
 		expect( store.dispatch ).toBeCalledWith( expectedAction, {
@@ -125,7 +125,7 @@ describe( 'AddressForms.vue', () => {
 	it( 'sets email in store when it receives email event', async () => {
 		const testEmail = 'test@wikimedia.de';
 		store.dispatch = jest.fn();
-		await wrapper.find( '#email' ).setValue( testEmail );
+		await wrapper.find( '#person-email' ).setValue( testEmail );
 
 		const expectedAction = action( NS_ADDRESS, setAddressField );
 		wrapper.findComponent( EmailField ).vm.$emit( 'field-changed', 'email' );
@@ -172,8 +172,8 @@ describe( 'AddressForms.vue', () => {
 			},
 		} );
 
-		expect( wrapper.find( '#first-name' ).element.value ).toBe( firstName.value );
-		expect( wrapper.find( '#last-name' ).element.value ).toBe( lastName.value );
+		expect( wrapper.find( '#person-first-name' ).element.value ).toBe( firstName.value );
+		expect( wrapper.find( '#person-last-name' ).element.value ).toBe( lastName.value );
 		expect( store.state.address.validity.firstName ).not.toBe( Validity.RESTORED );
 		expect( store.state.address.validity.lastName ).not.toBe( Validity.RESTORED );
 	} );

--- a/tests/unit/components/pages/donation_form/AddressTypeBasic.spec.ts
+++ b/tests/unit/components/pages/donation_form/AddressTypeBasic.spec.ts
@@ -18,13 +18,13 @@ describe( 'AddressTypeBasic.vue', () => {
 		const wrapper = getWrapper( [], false );
 		const event = 'address-type';
 
-		const person = wrapper.find( `#addressType-${AddressTypeModel.PERSON.valueOf()}` );
+		const person = wrapper.find( `#addressType-0` );
 		await person.trigger( 'change' );
 
-		const company = wrapper.find( `#addressType-${AddressTypeModel.COMPANY.valueOf()}` );
+		const company = wrapper.find( `#addressType-1` );
 		await company.trigger( 'change' );
 
-		const anon = wrapper.find( `#addressType-${AddressTypeModel.ANON.valueOf()}` );
+		const anon = wrapper.find( `#addressType-2` );
 		await anon.trigger( 'change' );
 
 		expect( wrapper.emitted( event ) ).toHaveLength( 3 );
@@ -36,9 +36,9 @@ describe( 'AddressTypeBasic.vue', () => {
 	it( 'disables anonymous address type if supplied via disabledAddressTypes property', async () => {
 		// TODO test with person instead of company and expect it to *not* be disabled, because person is the fallback type
 		const wrapper = getWrapper( [ AddressTypeModel.ANON, AddressTypeModel.COMPANY ], true );
-		const person = wrapper.find( `#addressType-${AddressTypeModel.PERSON.valueOf()}` );
-		const company = wrapper.find( `#addressType-${AddressTypeModel.COMPANY.valueOf()}` );
-		const anonymous = wrapper.find<HTMLInputElement>( `#addressType-${AddressTypeModel.ANON.valueOf()}` );
+		const person = wrapper.find( `#addressType-0` );
+		const company = wrapper.find( `#addressType-1` );
+		const anonymous = wrapper.find<HTMLInputElement>( `#addressType-2` );
 
 		expect( person.attributes( 'disabled' ) ).toBeUndefined();
 		expect( company.attributes( 'disabled' ) ).toBeDefined();

--- a/tests/unit/components/pages/membership_form/Payment.spec.ts
+++ b/tests/unit/components/pages/membership_form/Payment.spec.ts
@@ -51,11 +51,11 @@ describe( 'Payment.vue', () => {
 		const wrapper = getWrapper();
 		expect( wrapper.findComponent( PaymentBankData ).exists() ).toBeFalsy();
 
-		await wrapper.find( '#paymentType-BEZ' ).trigger( 'change' );
+		await wrapper.find( '[name="paymentType"][value="BEZ"]' ).trigger( 'change' );
 
 		expect( wrapper.findComponent( PaymentBankData ).exists() ).toBeTruthy();
 
-		await wrapper.find( '#paymentType-UEB' ).trigger( 'change' );
+		await wrapper.find( '[name="paymentType"][value="UEB"]' ).trigger( 'change' );
 
 		expect( wrapper.findComponent( PaymentBankData ).exists() ).toBeFalsy();
 	} );
@@ -113,7 +113,7 @@ describe( 'Payment.vue', () => {
 	it( 'Does not show fee error when field is empty and interval changes', async () => {
 		const wrapper = getWrapper();
 
-		await wrapper.find( '#interval-12' ).trigger( 'click' );
+		await wrapper.find( '[name="interval"][value="12"]' ).trigger( 'click' );
 
 		expect( wrapper.find( '.form-field-amount .is-danger' ).exists() ).toBeFalsy();
 	} );
@@ -122,7 +122,7 @@ describe( 'Payment.vue', () => {
 		const wrapper = getWrapper();
 
 		await wrapper.find( 'input[name="amount"][value="10000"]' ).trigger( 'click' );
-		await wrapper.find( '#interval-12' ).trigger( 'click' );
+		await wrapper.find( '[name="interval"][value="12"]' ).trigger( 'click' );
 
 		expect( wrapper.find( '.form-field-amount .is-danger' ).exists() ).toBeFalsy();
 	} );
@@ -131,7 +131,7 @@ describe( 'Payment.vue', () => {
 		const wrapper = getWrapper();
 
 		await wrapper.find( 'input[name="amount"][value="500"]' ).trigger( 'click' );
-		await wrapper.find( '#interval-12' ).trigger( 'click' );
+		await wrapper.find( '[name="interval"][value="12"]' ).trigger( 'click' );
 
 		expect( wrapper.find( '.form-field-amount .is-danger' ).exists() ).toBeFalsy();
 	} );

--- a/tests/unit/components/shared/form_elements/CheckboxMultipleFormInput.spec.ts
+++ b/tests/unit/components/shared/form_elements/CheckboxMultipleFormInput.spec.ts
@@ -9,7 +9,7 @@ describe( 'CheckboxMultipleFormInput.vue', () => {
 				modelValue: [],
 				nativeValue: 'pike',
 				name: 'captain',
-				inputId: 'pike',
+				inputId: 'captain',
 				disabled: false,
 				required: false,
 			},

--- a/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
@@ -14,6 +14,7 @@ describe( 'CityAutocompleteField.vue', () => {
 			props: {
 				modelValue: '',
 				label: '',
+				inputId: 'city',
 				examplePlaceholder: '',
 				showError: false,
 				errorMessage: 'I haz error',

--- a/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
@@ -11,6 +11,7 @@ describe( 'CountryAutocompleteField.vue', () => {
 				modelValue,
 				countries,
 				label: '',
+				inputId: 'country',
 				placeholder: '',
 				showError: false,
 				errorMessage: 'I haz error',

--- a/tests/unit/components/shared/form_fields/MailingListField.spec.ts
+++ b/tests/unit/components/shared/form_fields/MailingListField.spec.ts
@@ -7,6 +7,7 @@ describe( 'MailingListField.vue', () => {
 		return mount( MailingListField, {
 			props: {
 				modelValue: true,
+				inputId: 'newsletter',
 			},
 		} );
 	};

--- a/tests/unit/components/shared/form_fields/RadioField.spec.ts
+++ b/tests/unit/components/shared/form_fields/RadioField.spec.ts
@@ -10,8 +10,8 @@ describe( 'RadioField.vue', () => {
 				label: '',
 				name: 'animal',
 				options: [
-					{ value: 'mouse', label: 'Mouse' },
-					{ value: 'elephant', label: 'Elephant' },
+					{ value: 'mouse', label: 'Mouse', id: 'animal-0' },
+					{ value: 'elephant', label: 'Elephant', id: 'animal-1' },
 				],
 				errorMessage: 'error_message',
 				alignment: 'row',
@@ -22,8 +22,8 @@ describe( 'RadioField.vue', () => {
 	it( 'fill options', () => {
 		const wrapper = getWrapper();
 
-		expect( wrapper.find( '#animal-mouse' ).exists() ).toBeTruthy();
-		expect( wrapper.find( '#animal-elephant' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#animal-0' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#animal-1' ).exists() ).toBeTruthy();
 	} );
 
 	it( 'shows the error message', async () => {
@@ -58,7 +58,7 @@ describe( 'RadioField.vue', () => {
 	it( 'emits events', async () => {
 		const wrapper = getWrapper();
 
-		await wrapper.find( '#animal-elephant' ).trigger( 'change' );
+		await wrapper.find( '#animal-1' ).trigger( 'change' );
 
 		expect( wrapper.emitted( 'update:modelValue' ).length ).toStrictEqual( 1 );
 		expect( wrapper.emitted( 'update:modelValue' )[ 0 ][ 0 ] ).toStrictEqual( 'elephant' );

--- a/tests/unit/components/shared/form_fields/SelectField.spec.ts
+++ b/tests/unit/components/shared/form_fields/SelectField.spec.ts
@@ -8,6 +8,7 @@ describe( 'SelectField.vue', () => {
 			props: {
 				label: 'select',
 				name: 'select',
+				inputId: 'select',
 				modelValue: 'rolly',
 				options: [
 					{ value: 'bingo', label: 'Bingo' },


### PR DESCRIPTION
There are 3 forms on the donation page that had duplicated fields causing the screen reader to read all of them.

- Adds namespacing for the forms so each field has a unique id and label attached
- Adds parameters for explicitly setting ids to form fields
- Fix tests and hookups

Ticket: https://phabricator.wikimedia.org/T362951