### PR TITLE
Fix -- Main logo graphic for screen reader

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="navigation">
-		<a class="navigation-left" :href="`/?${ campaignParams }`" aria-hidden="true">
+		<a class="navigation-left" :href="`/?${ campaignParams }`">
+			<span class="visually-hidden">Wikimedia Deutschland e V.</span>
 			<Logo/>
 		</a>
 		<nav
@@ -70,6 +71,17 @@ const headerMenu = [
 $navbar-breakpoint: 600px;
 // Keep the logo and language links equal width so the navigation will be centered
 $side-width: 80px;
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	border: 0;
+}
 
 .navigation {
 	position: fixed;

--- a/src/components/layout/Logo.vue
+++ b/src/components/layout/Logo.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="wikimedia-logo-graphic">
 		<!-- eslint-disable max-len -->
-		<svg width="36" height="37" viewBox="0 0 36 37" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<svg width="36" height="37" viewBox="0 0 36 37" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 			<g filter="url(#filter0_i_1201_240)">
 				<path fill-rule="evenodd" clip-rule="evenodd"
 					d="M19.5635 29.0678C24.9393 28.3082 29.0748 23.6884 29.0748 18.1022C29.0748 14.7082 27.5481 11.6716 25.1448 9.63965L19.5635 15.2217V29.0678ZM16.4371 29.0678V15.2217L10.8562 9.63965C8.45247 11.6713 6.92578 14.7082 6.92578 18.1022C6.92578 23.6884 11.0615 28.3082 16.4371 29.0678Z"


### PR DESCRIPTION
- This fixes the issue with this PR: https://github.com/wmde/fundraising-app-frontend/pull/350
- Main logo can not be reached by keyboard navigation
- Screen reader will read a 'title' of the organization

Ticket: https://phabricator.wikimedia.org/T361808

Deployed to: https://testing04.wikimedia.customers.manitu.net/