### PR TITLE
Fix autocomplete IDs for postcode

### DIFF
--- a/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
@@ -52,7 +52,7 @@
 			v-model="formData.postcode.value"
 			:show-error="showError.postcode"
 			:error-message="$t('donation_form_zip_error')"
-			autocomplete="street-address"
+			autocomplete="postal-code"
 			:label="$t( 'donation_form_zip_label' )"
 			:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_zip_placeholder' ) } )"
 			@field-changed="$emit('field-changed', 'postcode')"

--- a/src/components/shared/PostalAddressFields.vue
+++ b/src/components/shared/PostalAddressFields.vue
@@ -31,7 +31,7 @@
 			v-model="formData.postcode.value"
 			:show-error="showError.postcode"
 			:error-message="$t('donation_form_zip_error')"
-			autocomplete="street-address"
+			autocomplete="postal-code"
 			:label="$t( 'donation_form_zip_label' )"
 			:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_zip_placeholder' ) } )"
 			@field-changed="$emit('field-changed', 'postcode')"


### PR DESCRIPTION
Autocomplete IDs for postcode had the wrong value (`street-address`
instead of `postal-code`).

See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete for a list of valid autocomplete IDs
