### PR TITLE
Fix nested link button

### DIFF
--- a/src/components/pages/donation_confirmation/MembershipInfo.vue
+++ b/src/components/pages/donation_confirmation/MembershipInfo.vue
@@ -3,8 +3,8 @@
 		<h2 class="icon-title"><warning-icon/> {{ $t( 'donation_confirmation_membership_call_to_action_title' ) }}</h2>
 		<p>{{ $t( 'donation_confirmation_membership_call_to_action_text' ) }}</p>
 		<p>
-			<a ref="buttonRef" id="membership-application-url" :href="membershipApplicationUrl">
-				<FormButton>{{ $t('donation_confirmation_membership_button') }}</FormButton>
+			<a ref="buttonRef" class="form-button" id="membership-application-url" :href="membershipApplicationUrl">
+				{{ $t('donation_confirmation_membership_button') }}
 			</a>
 		</p>
 		<ul class="membership-benefits">
@@ -21,7 +21,6 @@
 import { computed, inject, onMounted, onUnmounted, ref } from 'vue';
 import { Donation } from '@src/view_models/Donation';
 import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
-import FormButton from '@src/components/shared/form_elements/FormButton.vue';
 import { QUERY_STRING_INJECTION_KEY } from '@src/util/createCampaignQueryString';
 
 interface Props {

--- a/src/components/shared/form_elements/FormButton.vue
+++ b/src/components/shared/form_elements/FormButton.vue
@@ -30,6 +30,7 @@ withDefaults( defineProps<Props>(), {
 @use 'sass:map';
 
 .form-button {
+	display: inline-block;
 	background: colors.$primary;
 	color: colors.$white;
 	border: 0;
@@ -38,12 +39,16 @@ withDefaults( defineProps<Props>(), {
 	margin: 0;
 	font-size: 1em;
 	font-weight: 700;
+	text-align: center;
 	height: 54px;
 	width: 240px;
 	cursor: pointer;
 	transition: background-color 200ms global.$easing, color 200ms global.$easing;
 
-	&:hover {
+	&:hover,
+	&:focus {
+		color: colors.$white;
+		text-decoration: none;
 		background: color.adjust( colors.$primary, $lightness: -5% );
 	}
 
@@ -57,6 +62,10 @@ withDefaults( defineProps<Props>(), {
 			color: colors.$white;
 		}
 	}
+}
+
+a.form-button {
+	line-height: 54px;
 }
 
 </style>


### PR DESCRIPTION
The membership button on the donation confirmation was a
button inside a link. This makes it a link only.

Also added styles to the form button to cover the missing
styles for links that should look like buttons.