### PR TITLE
Fix issues with address updates on confirmation page 

### DIFF
--- a/src/components/pages/donation_confirmation/AddressUpdateForm.vue
+++ b/src/components/pages/donation_confirmation/AddressUpdateForm.vue
@@ -31,6 +31,11 @@
 				:form-data="formData"
 				:salutations="salutations"
 				:address-type="addressType"
+				:address-types-to-show-personal-fields="[
+					AddressTypeModel.PERSON,
+					AddressTypeModel.EMAIL,
+					AddressTypeModel.ANON,
+				]"
 				@field-changed="onFieldChange"
 			/>
 
@@ -218,14 +223,11 @@ watch( addressTypeModel, ( newAddressType: AddressTypeModel ) => setAddressType(
 const mailingList = ref<boolean>( MAILING_LIST_ADDRESS_PAGE );
 
 const validateForm = async (): Promise<ValidationResult> => {
-	let response = await store.dispatch( action( NS_ADDRESS, validateAddressType ), {
-		type: store.state.address.addressType,
-		disallowed: [ AddressTypeModel.UNSET, AddressTypeModel.ANON ],
-	} );
-	if ( response.status !== 'OK' ) {
-		return Promise.resolve( response );
-	}
-	let results = await Promise.all( [
+	const results = await Promise.all( [
+		store.dispatch( action( NS_ADDRESS, validateAddressType ), {
+			type: store.state.address.addressType,
+			disallowed: [ AddressTypeModel.UNSET, AddressTypeModel.ANON, AddressTypeModel.EMAIL ],
+		} ),
 		store.dispatch( action( NS_ADDRESS, validateAddress ), props.validateAddressUrl ),
 		store.dispatch( action( NS_ADDRESS, validateEmail ), props.validateEmailUrl ),
 	] );

--- a/src/components/pages/donation_confirmation/AddressUpdateFormErrorSummaries.vue
+++ b/src/components/pages/donation_confirmation/AddressUpdateFormErrorSummaries.vue
@@ -1,6 +1,6 @@
 <template>
 	<ErrorSummary
-		v-if="addressType === AddressTypeModel.PERSON || addressType === AddressTypeModel.ANON"
+		v-if="addressType === AddressTypeModel.PERSON || addressType === AddressTypeModel.ANON || addressType === AddressTypeModel.EMAIL"
 		:is-visible="showErrorSummary"
 		:items="[
 			{
@@ -66,68 +66,38 @@
 			{
 				validity: store.state.address.validity.companyName,
 				message: $t( 'donation_form_companyname_error' ),
-				focusElement: 'company-company-name',
-				scrollElement: 'company-company-name-scroll-target'
+				focusElement: 'company-name',
+				scrollElement: 'company-name-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.street,
 				message: $t( 'donation_form_street_error' ),
-				focusElement: 'company-street',
-				scrollElement: 'company-street-scroll-target'
+				focusElement: 'street',
+				scrollElement: 'street-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.postcode,
 				message: $t( 'donation_form_zip_error' ),
-				focusElement: 'company-post-code',
-				scrollElement: 'company-post-code-scroll-target'
+				focusElement: 'post-code',
+				scrollElement: 'post-code-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.city,
 				message: $t( 'donation_form_city_error' ),
-				focusElement: 'company-city',
-				scrollElement: 'company-city-scroll-target'
+				focusElement: 'city',
+				scrollElement: 'city-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.country,
 				message: $t( 'donation_form_country_error' ),
-				focusElement: 'company-country',
-				scrollElement: 'company-country-scroll-target'
+				focusElement: 'country',
+				scrollElement: 'country-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.email,
 				message: $t( 'donation_form_email_error' ),
-				focusElement: 'company-email',
-				scrollElement: 'company-email-scroll-target'
-			},
-		]"
-	/>
-	<ErrorSummary
-		v-if="addressType === AddressTypeModel.EMAIL"
-		:is-visible="showErrorSummary"
-		:items="[
-			{
-				validity: store.state.address.validity.salutation,
-				message: $t( 'donation_form_salutation_error' ),
-				focusElement: 'email-salutation-0',
-				scrollElement: 'email-salutation-scroll-target'
-			},
-			{
-				validity: store.state.address.validity.firstName,
-				message: $t( 'donation_form_firstname_error' ),
-				focusElement: 'email-first-name',
-				scrollElement: 'email-first-name-scroll-target'
-			},
-			{
-				validity: store.state.address.validity.lastName,
-				message: $t( 'donation_form_lastname_error' ),
-				focusElement: 'email-last-name',
-				scrollElement: 'email-last-name-scroll-target'
-			},
-			{
-				validity: store.state.address.validity.email,
-				message: $t( 'donation_form_email_error' ),
-				focusElement: 'email-email',
-				scrollElement: 'email-email-scroll-target'
+				focusElement: 'email',
+				scrollElement: 'email-scroll-target'
 			},
 		]"
 	/>

--- a/src/components/shared/NameFields.vue
+++ b/src/components/shared/NameFields.vue
@@ -101,18 +101,19 @@ interface Props {
 	formData: AddressFormData;
 	showError: AddressValidity;
 	fieldIdNamespace?: string;
+	addressTypesToShowPersonalFields?: AddressTypeModel[];
 }
 
-const props = defineProps<Props>();
-defineEmits( [ 'field-changed' ] );
-
-const showPersonalFields = computed( () =>
-	[
+const props = withDefaults( defineProps<Props>(), {
+	addressTypesToShowPersonalFields: () => [
 		AddressTypeModel.PERSON,
 		AddressTypeModel.EMAIL,
 		AddressTypeModel.UNSET,
-	].includes( props.addressType )
-);
+	],
+} );
+defineEmits( [ 'field-changed' ] );
+
+const showPersonalFields = computed( () => props.addressTypesToShowPersonalFields.includes( props.addressType ) );
 const showCompanyFields = computed( () => props.addressType === AddressTypeModel.COMPANY );
 const fieldIdNamespace = props.fieldIdNamespace ? `${props.fieldIdNamespace}-` : '';
 const salutationFormOptions: CheckboxFormOption[] = props.salutations.map( ( x, index ) => (

--- a/src/store/address/constants.ts
+++ b/src/store/address/constants.ts
@@ -15,6 +15,16 @@ export const REQUIRED_FIELDS: AddressRequirements = {
 	[ AddressTypeModel.UNSET ]: [ 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'country', 'email', 'addressType' ],
 };
 
+export const REQUIRED_FIELDS_DONOR_UPDATE: AddressRequirements = {
+	[ AddressTypeModel.PERSON ]: [ 'addressType', 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'country', 'email' ],
+	[ AddressTypeModel.COMPANY ]: [ 'addressType', 'companyName', 'street', 'postcode', 'city', 'country', 'email' ],
+	[ AddressTypeModel.COMPANY_WITH_CONTACT ]: [ 'addressType', 'salutation', 'firstName', 'lastName', 'companyName', 'street', 'postcode', 'city', 'country', 'email' ],
+	// We show the person fields as default so if the address type before updating is email or anon we still need to validate them
+	[ AddressTypeModel.EMAIL ]: [ 'addressType', 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'country', 'email' ],
+	[ AddressTypeModel.ANON ]: [ 'addressType', 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'country', 'email' ],
+	[ AddressTypeModel.UNSET ]: [ 'addressType', 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'country', 'email' ],
+};
+
 export const REQUIRED_FIELDS_ADDRESS_UPDATE: AddressRequirements = {
 	[ AddressTypeModel.PERSON ]: [ 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'country' ],
 	[ AddressTypeModel.COMPANY ]: [ 'companyName', 'street', 'postcode', 'city', 'country' ],

--- a/src/store/address/mutations.ts
+++ b/src/store/address/mutations.ts
@@ -29,8 +29,8 @@ export const mutations: MutationTree<AddressState> = {
 		}
 	},
 	[ MARK_EMPTY_FIELDS_INVALID ]( state: AddressState ) {
+		let addressTypeRequirements = state.requiredFields[ state.addressType ];
 		state.requiredFields[ state.addressType ].forEach( ( fieldName: string ) => {
-			let addressTypeRequirements = state.requiredFields[ state.addressType ];
 			if ( state.validity[ fieldName ] === Validity.INCOMPLETE &&
 				addressTypeRequirements[ addressTypeRequirements.indexOf( fieldName ) ] ) {
 				state.validity[ fieldName ] = Validity.INVALID;

--- a/src/store/donor_update_store.ts
+++ b/src/store/donor_update_store.ts
@@ -1,12 +1,12 @@
 import Vuex, { StoreOptions } from 'vuex';
 import createAddress from '@src/store/address';
 import { NS_ADDRESS } from './namespaces';
-import { REQUIRED_FIELDS } from '@src/store/address/constants';
+import { REQUIRED_FIELDS_DONOR_UPDATE } from '@src/store/address/constants';
 
 export function createStore() {
 	const storeBundle: StoreOptions<any> = {
 		modules: {
-			[ NS_ADDRESS ]: createAddress( REQUIRED_FIELDS ),
+			[ NS_ADDRESS ]: createAddress( REQUIRED_FIELDS_DONOR_UPDATE ),
 		},
 		strict: process.env.NODE_ENV !== 'production',
 		getters: {

--- a/tests/unit/components/pages/donation_confirmation/AddressUpdateForm.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/AddressUpdateForm.spec.ts
@@ -1,5 +1,5 @@
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
-import { createStore } from '@src/store/donation_store';
+import { createStore } from '@src/store/donor_update_store';
 import AddressUpdateForm from '@src/components/pages/donation_confirmation/AddressUpdateForm.vue';
 import { action } from '@src/store/util';
 import { NS_ADDRESS } from '@src/store/namespaces';
@@ -55,6 +55,21 @@ const inValidAddress = {
 	city: '',
 	country: '',
 	email: 'not.a.real.email@domainlalalaxoxoxo.de',
+};
+
+const emptyAddress = {
+	addressType: '',
+	salutation: '',
+	title: '',
+	firstName: '',
+	lastName: '',
+	fullName: '',
+	companyName: '',
+	street: '',
+	postcode: '',
+	city: '',
+	country: '',
+	email: '',
 };
 
 const addressData = ( address: Address, addressType: AddressTypeModel ) => {
@@ -240,5 +255,69 @@ describe( 'AddressUpdateForm.vue', () => {
 
 		expect( wrapper.find( '.server-message' ).exists() ).toBe( true );
 		expect( wrapper.find( '.server-message' ).text() ).toStrictEqual( error );
+	} );
+
+	test.each( [
+		[ AddressTypeModel.PERSON ],
+		[ AddressTypeModel.EMAIL ],
+		[ AddressTypeModel.ANON ],
+	] )( 'shows and validates as person when initial address type is %s', async ( addressType: AddressTypeModel ) => {
+		const store = createStore();
+		await store.dispatch(
+			action( NS_ADDRESS, initializeAddress ),
+			addressData( emptyAddress, addressType )
+		);
+
+		const wrapper = getWrapper( store, bankTransferConfirmationData );
+
+		expect( wrapper.find( '#salutation-0' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#title' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#first-name' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#last-name' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#street' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#post-code' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#city' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#country' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#email' ).exists() ).toBeTruthy();
+
+		await wrapper.find( '#address-update-form' ).trigger( 'submit' );
+		await flushPromises();
+
+		expect( wrapper.find( '.error-summary' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#salutation-0"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#first-name"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#last-name"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#street"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#post-code"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#city"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#country"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#email"]' ).exists() ).toBeTruthy();
+	} );
+
+	it( 'shows and validates as company when address type is company', async () => {
+		const store = createStore();
+		emptyAddress.addressType = 'firma';
+		await store.dispatch(
+			action( NS_ADDRESS, initializeAddress ),
+			addressData( emptyAddress, AddressTypeModel.COMPANY )
+		);
+
+		const wrapper = getWrapper( store, bankTransferConfirmationData );
+
+		expect( wrapper.find( '#company-name' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#street' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#city' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#country' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '#email' ).exists() ).toBeTruthy();
+
+		await wrapper.find( '#address-update-form' ).trigger( 'submit' );
+		await flushPromises();
+
+		expect( wrapper.find( '.error-summary' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#company-name"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#street"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#city"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#country"]' ).exists() ).toBeTruthy();
+		expect( wrapper.find( '[href="#email"]' ).exists() ).toBeTruthy();
 	} );
 } );

--- a/tests/unit/components/shared/form_elements/PaymentTextFormButton.spec.ts
+++ b/tests/unit/components/shared/form_elements/PaymentTextFormButton.spec.ts
@@ -15,7 +15,7 @@ describe( 'PaymentTextFormButton.vue', () => {
 
 	test.each( cases )(
 		'given payment method %p the submit button shows %p',
-		( paymentMethod: string, expectedTranslationKey: string ) => {
+		( paymentMethod: 'PPL' | 'UEB' | 'MCP' | 'SUB', expectedTranslationKey: string ) => {
 
 			const wrapper = mount( PaymentTextFormButton, {
 				props: {


### PR DESCRIPTION
The update donor form on the confirmation page wasn't catching
all combinations of address type when validating and letting
post submissions happen.

- Add new validation rules for update donor
- Use correct store in donor update tests
- Fix the validation summaries
- Add option to NameFields to allow customisation of what address
  types to display person fields for
- Fix a couple of small linting issues

Ticket: https://phabricator.wikimedia.org/T369023