### PR TITLE
Unify SCSS @include order

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -31,12 +31,13 @@
 		select {
 			border-radius: 0;
 			width: $fun-min-width;
-			@include from($tablet) {
-				width: $fun-max-width;
-			}
 			font-size: 1rem;
 			line-height: 40px;
 			height: 48px;
+
+			@include from($tablet) {
+				width: $fun-max-width;
+			}
 		}
 		// Bulma has different types of dropdowns with selectors like these
 		// This modifies a "normal" selection dropdown list to accommodate for the custom size we apply
@@ -109,11 +110,12 @@ h2.form-subtitle {
 .has-outside-border {
 	margin: -10px; /* half of column gap +1 pixel for border */
 	padding: 8px; /* add back column gap -1 pixel border */
+	border: solid 2px colors.$gray-light;
+
 	@include from($tablet) {
 		margin:  1 - $column-gap;
 		padding: $column-gap - 1;
 	}
-	border: solid 2px colors.$gray-light;
 }
 
 .content .faq-item {

--- a/src/scss/overrides.scss
+++ b/src/scss/overrides.scss
@@ -33,13 +33,15 @@
 .fun-radio.radio {
 	height: auto;
 	width: 380px;
-	@include from($tablet) {
-		width: $fun-max-width;
-	}
-    border-bottom: 2px solid colors.$very-transparent-black;
+	border-bottom: 2px solid colors.$very-transparent-black;
 	align-items: flex-start;
 	padding-bottom: 1.5em;
 	padding-top: 1.5em;
+
+	@include from($tablet) {
+	  width: $fun-max-width;
+	}
+
 	&:hover {
 		border-bottom: 2px solid colors.$gray-dark;
 	}
@@ -202,7 +204,7 @@ a:focus {
 }
 
 a[disabled=disabled] {
-    color: gray;
+	color: gray;
 	cursor: default;
 	&:hover {
 		text-decoration: none;


### PR DESCRIPTION
New version of SCSS gave a deprecation warning when `@include` was
followed by style rules. This commit fixes the order.
See https://sass-lang.com/d/mixed-decls
