### PR TITLE
Add scroll into view to city & country autocomplete

### DIFF
--- a/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
@@ -90,6 +90,7 @@
 		<CountryAutocompleteField
 			v-model="formData.country.value"
 			input-id="country"
+			scroll-target-id="country-scroll-target"
 			:countries="countries"
 			:was-restored="countryWasRestored"
 			:show-error="showError.country"

--- a/src/components/shared/PostalAddressFields.vue
+++ b/src/components/shared/PostalAddressFields.vue
@@ -71,6 +71,7 @@
 		<CountryAutocompleteField
 			v-model="formData.country.value"
 			:input-id="`${fieldIdNamespace}country`"
+			:scroll-target-id="`${fieldIdNamespace}country-scroll-target`"
 			:countries="countries"
 			:was-restored="countryWasRestored"
 			:show-error="showError.country"

--- a/src/components/shared/form_fields/CityAutocompleteField.vue
+++ b/src/components/shared/form_fields/CityAutocompleteField.vue
@@ -63,6 +63,7 @@ enum InteractionState {
 interface Props {
 	modelValue: string;
 	inputId: string;
+	scrollTargetId: string;
 	label: String;
 	examplePlaceholder: string;
 	showError: boolean;
@@ -92,8 +93,16 @@ const placeholder = computed( () => {
 	return 'form_for_example';
 } );
 
+const scrollIntoView = (): void => {
+	const scrollIntoViewElement = document.getElementById( props.scrollTargetId );
+	if ( scrollIntoViewElement ) {
+		scrollIntoViewElement.scrollIntoView( { behavior: 'smooth' } );
+	}
+};
+
 const onFocus = ( event: Event ) => {
 	autocompleteIsActive.value = true;
+	scrollIntoView();
 	( event.target as HTMLInputElement ).select();
 };
 

--- a/src/components/shared/form_fields/CountryAutocompleteField.vue
+++ b/src/components/shared/form_fields/CountryAutocompleteField.vue
@@ -67,6 +67,7 @@ enum InteractionState {
 interface Props {
 	modelValue: string;
 	inputId: string;
+	scrollTargetId: string;
 	label: String;
 	placeholder: String;
 	countries?: Array<Country>;
@@ -98,6 +99,13 @@ const isFirstFocusOnDefaultValue = (): boolean => {
 	return !wasFocusedBefore.value && !props.wasRestored;
 };
 
+const scrollIntoView = (): void => {
+	const scrollIntoViewElement = document.getElementById( props.scrollTargetId );
+	if ( scrollIntoViewElement ) {
+		scrollIntoViewElement.scrollIntoView( { behavior: 'smooth' } );
+	}
+};
+
 const onFocus = ( event: Event ) => {
 	if ( isFirstFocusOnDefaultValue() ) {
 		countryName.value = '';
@@ -105,6 +113,7 @@ const onFocus = ( event: Event ) => {
 	wasFocusedBefore.value = true;
 
 	autocompleteIsActive.value = true;
+	scrollIntoView();
 	( event.target as HTMLInputElement ).select();
 };
 

--- a/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
@@ -8,16 +8,21 @@ const placeholderKey = 'form_for_example';
 const placeholderKeyWhenSuggestionsExist = 'form_autocomplete_prompt';
 
 describe( 'CityAutocompleteField.vue', () => {
+	let scrollElement: { scrollIntoView: jest.Mock };
 
 	const getWrapper = ( postcode: string = '' ): VueWrapper<any> => {
 		const currentElement = { clientHeight: 0, offsetTop: 0 };
 		Object.defineProperty( document, 'querySelector', { writable: true, configurable: true, value: () => currentElement } );
+
+		scrollElement = { scrollIntoView: jest.fn() };
+		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => scrollElement } );
 
 		return mount( CityAutocompleteField, {
 			props: {
 				modelValue: '',
 				label: '',
 				inputId: 'city',
+				scrollTargetId: 'scroll',
 				examplePlaceholder: '',
 				showError: false,
 				errorMessage: 'I haz error',
@@ -213,5 +218,13 @@ describe( 'CityAutocompleteField.vue', () => {
 		await wrapper.setProps( { showError: true } );
 
 		expect( field.attributes( 'aria-describedby' ) ).toStrictEqual( 'city-selected city-error' );
+	} );
+
+	it( 'scrolls field into view when focused', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find<HTMLInputElement>( '#city' ).trigger( 'focus' );
+
+		expect( scrollElement.scrollIntoView ).toHaveBeenCalled();
 	} );
 } );

--- a/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
@@ -4,9 +4,14 @@ import CountryAutocompleteField from '@src/components/shared/form_fields/Country
 import countries from '@test/data/countries';
 
 describe( 'CountryAutocompleteField.vue', () => {
+	let scrollElement: { scrollIntoView: jest.Mock };
+
 	const getWrapper = ( modelValue: string = '', wasRestored: boolean = false ): VueWrapper<any> => {
 		const currentElement = { clientHeight: 0, offsetTop: 0 };
 		Object.defineProperty( document, 'querySelector', { writable: true, configurable: true, value: () => currentElement } );
+
+		scrollElement = { scrollIntoView: jest.fn() };
+		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => scrollElement } );
 
 		return mount( CountryAutocompleteField, {
 			props: {
@@ -14,6 +19,7 @@ describe( 'CountryAutocompleteField.vue', () => {
 				countries,
 				label: '',
 				inputId: 'country',
+				scrollTargetId: 'scroll',
 				placeholder: '',
 				showError: false,
 				errorMessage: 'I haz error',
@@ -248,5 +254,13 @@ describe( 'CountryAutocompleteField.vue', () => {
 		await wrapper.setProps( { showError: true } );
 
 		expect( field.attributes( 'aria-describedby' ) ).toStrictEqual( 'country-selected country-error' );
+	} );
+
+	it( 'scrolls field into view when focused', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find<HTMLInputElement>( '#country' ).trigger( 'focus' );
+
+		expect( scrollElement.scrollIntoView ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
When a donor focuses an autocomplete field scroll it
into view so they know an autocomplete exists.

Ticket: https://phabricator.wikimedia.org/T370525