### PR TITLE
Add id to country autocomplete error

### DIFF
--- a/src/components/shared/form_fields/CountryAutocompleteField.vue
+++ b/src/components/shared/form_fields/CountryAutocompleteField.vue
@@ -44,7 +44,7 @@
 				</div>
 			</transition>
 		</div>
-		<span v-if="showError" class="help is-danger">{{ errorMessage }}</span>
+		<span v-if="showError" class="help is-danger" :id="`${inputId}-error`">{{ errorMessage }}</span>
 		<slot name="message"/>
 	</div>
 </template>


### PR DESCRIPTION
The error message in the country field was missing an id
causing the aria-describedby to not find it.

Ticket: https://phabricator.wikimedia.org/T366884