### PR TITLE
Improve Woodpecker CI steps

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -6,7 +6,7 @@
 steps:
     -   name: build
         when: 
-          - event: [ push, cron, manual ]
+          - event: [ push, pull_request_closed, cron, manual ]
             branch:
               exclude: [ dependabot/* ]
         image: node:20-alpine


### PR DESCRIPTION
Build on `pull_request_closed` event to generate `main.tar.gz`. Previous
changes assumed that merges would be handled like a push to `main`, but
that's not the case
