### PR TITLE
change link to membership info page

### DIFF
--- a/src/components/pages/donation_confirmation/MembershipInfo.vue
+++ b/src/components/pages/donation_confirmation/MembershipInfo.vue
@@ -12,7 +12,11 @@
 			<li>{{ $t( 'donation_confirmation_bottombox_membership_benefit_2' ) }}</li>
 			<li>{{ $t( 'donation_confirmation_bottombox_membership_benefit_3' ) }}</li>
 			<li>{{ $t( 'donation_confirmation_bottombox_membership_benefit_4' ) }}</li>
-			<li><a href="https://wikimedia.de/de/mitglied-werden">{{ $t( 'donation_confirmation_bottombox_membership_link' ) }}</a></li>
+			<li>
+				<a href="https://www.wikimedia.de/wikipedia-unterstuetzen/spenden/mitglieder/">
+					{{ $t( 'donation_confirmation_bottombox_membership_link' ) }}
+				</a>
+			</li>
 		</ul>
 	</div>
 </template>


### PR DESCRIPTION
The URL of the membership info page at www.wikimedia.de was changed and there is no redirect setup for old URLs. This pull request changes the URL to the current one.