### PR TITLE
Add validation and error summary to comment form

### DIFF
--- a/src/api/CommentResource.ts
+++ b/src/api/CommentResource.ts
@@ -26,8 +26,8 @@ export class ApiCommentResource implements CommentResource {
 
 	post( data: CommentRequest ): Promise<string> {
 		return axios.post( this.postEndpoint, data ).then( ( validationResult: AxiosResponse<CommentResponse> ) => {
-			if ( validationResult.data.status === 'OK' ) {
-				return Promise.reject();
+			if ( validationResult.data.status !== 'OK' ) {
+				return Promise.reject( validationResult.data.message );
 			}
 			return validationResult.data.message;
 		} );

--- a/src/api/CommentResource.ts
+++ b/src/api/CommentResource.ts
@@ -1,0 +1,35 @@
+import axios, { AxiosResponse } from 'axios';
+
+export interface CommentRequest {
+	donationId: number;
+	updateToken: string;
+	comment: string;
+	withName: boolean;
+	isPublic: boolean;
+}
+
+interface CommentResponse {
+	status: string;
+	message: string;
+}
+
+export interface CommentResource {
+	post: ( data: CommentRequest ) => Promise<string>;
+}
+
+export class ApiCommentResource implements CommentResource {
+	postEndpoint: string;
+
+	constructor( postEndpoint: string ) {
+		this.postEndpoint = postEndpoint;
+	}
+
+	post( data: CommentRequest ): Promise<string> {
+		return axios.post( this.postEndpoint, data ).then( ( validationResult: AxiosResponse<CommentResponse> ) => {
+			if ( validationResult.data.status === 'OK' ) {
+				return Promise.reject();
+			}
+			return validationResult.data.message;
+		} );
+	}
+}

--- a/src/pages/donation_confirmation.ts
+++ b/src/pages/donation_confirmation.ts
@@ -21,6 +21,7 @@ import DonationConfirmation from '@src/components/pages/DonationConfirmation.vue
 import { createFeatureFetcher } from '@src/util/FeatureFetcher';
 import { bucketIdToCssClass } from '@src/util/bucket_id_to_css_class';
 import { ApiCityAutocompleteResource } from '@src/api/CityAutocompleteResource';
+import { ApiCommentResource } from '@src/api/CommentResource';
 
 interface DonationConfirmationModel {
 	urls: { [ key: string ]: string },
@@ -93,5 +94,6 @@ store.dispatch(
 		} );
 	app.use( store );
 	app.provide( 'cityAutocompleteResource', new ApiCityAutocompleteResource() );
+	app.provide( 'commentResource', new ApiCommentResource( pageData.applicationVars.urls.postComment ) );
 	app.mount( '#app' );
 } );

--- a/tests/unit/TestDoubles/FakeCommentResource.ts
+++ b/tests/unit/TestDoubles/FakeCommentResource.ts
@@ -1,0 +1,15 @@
+import { CommentResource } from '@src/api/CommentResource';
+
+export const successMessage = 'Success';
+
+export class FakeSucceedingCommentResource implements CommentResource {
+	post(): Promise<string> {
+		return Promise.resolve( successMessage );
+	}
+}
+
+export class FakeFailingCommentResource implements CommentResource {
+	post(): Promise<string> {
+		return Promise.reject();
+	}
+}

--- a/tests/unit/TestDoubles/FakeCommentResource.ts
+++ b/tests/unit/TestDoubles/FakeCommentResource.ts
@@ -1,6 +1,7 @@
 import { CommentResource } from '@src/api/CommentResource';
 
 export const successMessage = 'Success';
+export const failureMessage = 'Fail';
 
 export class FakeSucceedingCommentResource implements CommentResource {
 	post(): Promise<string> {
@@ -10,6 +11,6 @@ export class FakeSucceedingCommentResource implements CommentResource {
 
 export class FakeFailingCommentResource implements CommentResource {
 	post(): Promise<string> {
-		return Promise.reject();
+		return Promise.reject( failureMessage );
 	}
 }

--- a/tests/unit/components/pages/donation_confirmation/DonationConfirmation.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/DonationConfirmation.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '@test/data/confirmationData';
 import { addressValidationPatterns } from '@test/data/validation';
 import { DonorResource } from '@src/api/DonorResource';
+import { FakeSucceedingCommentResource } from '@test/unit/TestDoubles/FakeCommentResource';
 
 describe( 'DonationConfirmation.vue', () => {
 	const getWrapper = ( bankData: ConfirmationData, translateMock: ( key: string ) => string = ( key: string ) => key ): VueWrapper<any> => {
@@ -38,6 +39,9 @@ describe( 'DonationConfirmation.vue', () => {
 				mocks: {
 					$t: translateMock,
 					$n: () => {},
+				},
+				provide: {
+					commentResource: new FakeSucceedingCommentResource(),
 				},
 			},
 		} );


### PR DESCRIPTION
- Pull axios out of the DonationCommentPopUp component and wraps it in a resource.
- Add tests for post response handling
- Add check for empty comment on submit
- Add new error for when the comment is empty
- Add error type var to display the correct error
- Add tests

Ticket: https://phabricator.wikimedia.org/T367387