### PR TITLE
Fix missing prop in city autocomplete

### DIFF
--- a/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
@@ -72,6 +72,7 @@
 		<CityAutocompleteField
 			v-model="formData.city.value"
 			input-id="city"
+			scroll-target-id="city-scroll-target"
 			:show-error="showError.city"
 			:label="$t( 'donation_form_city_label' )"
 			:error-message="$t( 'donation_form_city_error' )"

--- a/src/components/pages/donation_form/StreetAutocomplete/PostalAddressFields.vue
+++ b/src/components/pages/donation_form/StreetAutocomplete/PostalAddressFields.vue
@@ -39,6 +39,7 @@
 		<CityAutocompleteField
 			v-model="formData.city.value"
 			:input-id="`${fieldIdNamespace}city`"
+			:scroll-target-id="`${fieldIdNamespace}city-scroll-target`"
 			:show-error="showError.city"
 			:label="$t( 'donation_form_city_label' )"
 			:error-message="$t( 'donation_form_city_error' )"

--- a/src/components/shared/PostalAddressFields.vue
+++ b/src/components/shared/PostalAddressFields.vue
@@ -51,6 +51,7 @@
 		<CityAutocompleteField
 			v-model="formData.city.value"
 			:input-id="`${fieldIdNamespace}city`"
+			:scroll-target-id="`${fieldIdNamespace}city-scroll-target`"
 			:show-error="showError.city"
 			:label="$t( 'donation_form_city_label' )"
 			:error-message="$t( 'donation_form_city_error' )"


### PR DESCRIPTION
This form field needs to know the scroll target so it can scroll the element into view when focused and make the autocomplete list visible.

It was set up to do the scroll but in some of the places the component was being used it wasn't being passed the scroll target id.