### PR TITLE
Add street autocomplete to alternate address form

### DIFF
--- a/src/components/pages/donation_form/AddressFormErrorSummaries.vue
+++ b/src/components/pages/donation_form/AddressFormErrorSummaries.vue
@@ -4,10 +4,10 @@
 		:is-visible="showErrorSummary"
 		:items="[
 			{
-				validity: store.getters[ 'bankdata/bankDataIsInvalid' ] ? Validity.INVALID : Validity.VALID,
+				validity: bankDataValidity,
 				message: $t( 'donation_form_payment_bankdata_error' ),
 				focusElement: 'account-number',
-				scrollElement: 'iban-scroll-target'
+				scrollElement: 'account-number-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.addressType,
@@ -70,10 +70,10 @@
 		:is-visible="showErrorSummary"
 		:items="[
 			{
-				validity: store.getters[ 'bankdata/bankDataIsInvalid' ] ? Validity.INVALID : Validity.VALID,
+				validity: bankDataValidity,
 				message: $t( 'donation_form_payment_bankdata_error' ),
 				focusElement: 'account-number',
-				scrollElement: 'iban-scroll-target'
+				scrollElement: 'account-number-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.companyName,
@@ -118,10 +118,10 @@
 		:is-visible="showErrorSummary"
 		:items="[
 			{
-				validity: store.getters[ 'bankdata/bankDataIsInvalid' ] ? Validity.INVALID : Validity.VALID,
+				validity: bankDataValidity,
 				message: $t( 'donation_form_payment_bankdata_error' ),
 				focusElement: 'account-number',
-				scrollElement: 'iban-scroll-target'
+				scrollElement: 'account-number-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.firstName,
@@ -151,6 +151,7 @@ import ErrorSummary from '@src/components/shared/validation_summary/ErrorSummary
 import { useStore } from 'vuex';
 import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
 import { Validity } from '@src/view_models/Validity';
+import { computed } from 'vue';
 
 interface Props {
 	showErrorSummary: boolean;
@@ -159,5 +160,6 @@ interface Props {
 
 defineProps<Props>();
 const store = useStore();
+const bankDataValidity = computed<Validity>( () => store.getters[ 'bankdata/bankDataIsInvalid' ] ? Validity.INVALID : Validity.VALID );
 
 </script>

--- a/src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue
@@ -1,0 +1,150 @@
+<template>
+	<div class="address-section">
+
+		<ScrollTarget target-id="address-type-scroll-target"/>
+		<RadioField
+			v-model="addressType"
+			name="addressTypeSelector"
+			:options="[
+				{ value: AddressTypeModel.PERSON, label: $t( 'C24_WMDE_Desktop_DE_01_contact_details_private' ), id: 'addressType-0' },
+				{ value: AddressTypeModel.COMPANY_WITH_CONTACT, label: $t( 'C24_WMDE_Desktop_DE_01_contact_details_company' ), id: 'addressType-1' },
+			]"
+			:label="$t( 'C24_WMDE_Desktop_DE_01_contact_details_label' )"
+			:show-error="showAddressTypeError"
+			:error-message="$t( 'donation_form_section_address_error' )"
+			alignment="row"
+		/>
+
+		<ScrollTarget target-id="company-name-scroll-target"/>
+		<TextField
+			v-if="addressType === AddressTypeModel.COMPANY_WITH_CONTACT"
+			name="companyName"
+			input-id="company-name"
+			v-model="formData.companyName.value"
+			:show-error="showError.companyName"
+			:error-message="$t( 'donation_form_companyname_error' )"
+			autocomplete="organization"
+			:label="$t( 'donation_form_companyname_label' )"
+			:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_companyname_placeholder' ) } )"
+			@field-changed="$emit('field-changed', 'companyName')"
+		/>
+
+		<ScrollTarget target-id="country-scroll-target"/>
+		<CountryAutocompleteField
+			v-model="formData.country.value"
+			input-id="country"
+			scroll-target-id="country-scroll-target"
+			:countries="countries"
+			:was-restored="countryWasRestored"
+			:show-error="showError.country"
+			:error-message="$t('donation_form_country_error')"
+			:label="$t( 'donation_form_country_label' )"
+			:placeholder="$t( 'form_for_example', { example: countries[0].countryFullName } )"
+			@field-changed="onCountryFieldChanged"
+		/>
+
+		<ScrollTarget target-id="post-code-scroll-target"/>
+		<TextField
+			name="postcode"
+			input-id="post-code"
+			v-model="formData.postcode.value"
+			:show-error="showError.postcode"
+			:error-message="$t('donation_form_zip_error')"
+			autocomplete="postal-code"
+			:label="$t( 'donation_form_zip_label' )"
+			:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_zip_placeholder' ) } )"
+			@field-changed="$emit('field-changed', 'postcode')"
+		>
+			<ValueEqualsPlaceholderWarning
+				:value="formData.postcode.value"
+				:placeholder="$t( 'donation_form_zip_placeholder' )"
+				:warning="'donation_form_zip_placeholder_warning'"
+			/>
+		</TextField>
+
+		<ScrollTarget target-id="city-scroll-target"/>
+		<CityAutocompleteField
+			v-model="formData.city.value"
+			input-id="city"
+			scroll-target-id="city-scroll-target"
+			:show-error="showError.city"
+			:label="$t( 'donation_form_city_label' )"
+			:error-message="$t( 'donation_form_city_error' )"
+			:postcode="formData.postcode.value"
+			example-placeholder="donation_form_city_placeholder"
+			@field-changed="$emit('field-changed', 'city' )"
+		>
+			<ValueEqualsPlaceholderWarning
+				:value="formData.city.value"
+				:placeholder="$t( 'donation_form_city_placeholder' )"
+				warning="donation_form_city_placeholder_warning"
+			/>
+		</CityAutocompleteField>
+
+		<ScrollTarget target-id="street-scroll-target"/>
+		<StreetAutocompleteField
+			input-id-street-name="street"
+			input-id-building-number="building-number"
+			scroll-target-id="street-scroll-target"
+			v-model="formData.street.value"
+			:postcode="formData.postcode.value"
+			:show-error="showError.street"
+			:error-message="$t( 'donation_form_street_error' )"
+			@field-changed="$emit('field-changed', 'street' )"
+		/>
+
+	</div>
+</template>
+
+<script setup lang="ts">
+
+import RadioField from '@src/components/shared/form_fields/RadioField.vue';
+import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
+import { useStore } from 'vuex';
+import { StoreKey } from '@src/store/donation_store';
+import { useAddressTypeModel } from '@src/components/pages/donation_form/DonationReceipt/useAddressTypeModel';
+import { AddressFormData, AddressValidity } from '@src/view_models/Address';
+import TextField from '@src/components/shared/form_fields/TextField.vue';
+import ValueEqualsPlaceholderWarning from '@src/components/shared/ValueEqualsPlaceholderWarning.vue';
+import { computed } from 'vue';
+import CityAutocompleteField from '@src/components/shared/form_fields/CityAutocompleteField.vue';
+import CountryAutocompleteField from '@src/components/shared/form_fields/CountryAutocompleteField.vue';
+import { Country } from '@src/view_models/Country';
+import ScrollTarget from '@src/components/shared/ScrollTarget.vue';
+import StreetAutocompleteField from '@src/components/shared/form_fields/StreetAutocompleteField.vue';
+
+interface Props {
+	formData: AddressFormData;
+	showError: AddressValidity;
+	countries: Country[];
+	postCodeValidation: string;
+	countryWasRestored: boolean;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'field-changed' ] );
+
+const store = useStore( StoreKey );
+const addressType = useAddressTypeModel( store );
+
+const showAddressTypeError = computed( () => store.getters[ 'address/addressTypeIsInvalid' ] );
+
+const onCountryFieldChanged = ( country: Country | undefined ) => {
+	if ( country ) {
+		props.formData.postcode.pattern = country.postCodeValidation;
+	} else {
+		props.formData.postcode.pattern = props.postCodeValidation;
+	}
+
+	emit( 'field-changed', 'country' );
+
+	if ( props.formData.postcode.value !== '' ) {
+		emit( 'field-changed', 'postcode' );
+	}
+};
+
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/src/components/pages/donation_form/DonationReceipt/AddressFormErrorSummariesStreetAutocomplete.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFormErrorSummariesStreetAutocomplete.vue
@@ -82,10 +82,10 @@
 				scrollElement: 'address-type-scroll-target'
 			},
 			{
-				validity: store.state.address.validity.street,
-				message: $t( 'donation_form_street_error' ),
-				focusElement: 'street',
-				scrollElement: 'street-scroll-target'
+				validity: store.state.address.validity.country,
+				message: $t( 'donation_form_country_error' ),
+				focusElement: 'country',
+				scrollElement: 'country-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.postcode,
@@ -100,10 +100,10 @@
 				scrollElement: 'city-scroll-target'
 			},
 			{
-				validity: store.state.address.validity.country,
-				message: $t( 'donation_form_country_error' ),
-				focusElement: 'country',
-				scrollElement: 'country-scroll-target'
+				validity: store.state.address.validity.street,
+				message: $t( 'donation_form_street_error' ),
+				focusElement: 'street',
+				scrollElement: 'street-scroll-target'
 			},
 		]"
 	/>
@@ -154,10 +154,10 @@
 				scrollElement: 'company-name-scroll-target'
 			},
 			{
-				validity: store.state.address.validity.street,
-				message: $t( 'donation_form_street_error' ),
-				focusElement: 'street',
-				scrollElement: 'street-scroll-target'
+				validity: store.state.address.validity.country,
+				message: $t( 'donation_form_country_error' ),
+				focusElement: 'country',
+				scrollElement: 'country-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.postcode,
@@ -172,10 +172,10 @@
 				scrollElement: 'city-scroll-target'
 			},
 			{
-				validity: store.state.address.validity.country,
-				message: $t( 'donation_form_country_error' ),
-				focusElement: 'country',
-				scrollElement: 'country-scroll-target'
+				validity: store.state.address.validity.street,
+				message: $t( 'donation_form_street_error' ),
+				focusElement: 'street',
+				scrollElement: 'street-scroll-target'
 			},
 		]"
 	/>
@@ -229,7 +229,7 @@ interface Props {
 	showErrorSummary: boolean;
 	addressType: AddressTypeModel;
 	showReceiptOptionError: boolean;
-	receiptNeeded?: boolean;
+	receiptNeeded: boolean;
 }
 
 defineProps<Props>();

--- a/src/components/pages/donation_form/StreetAutocomplete/AddressFormErrorSummaries.vue
+++ b/src/components/pages/donation_form/StreetAutocomplete/AddressFormErrorSummaries.vue
@@ -4,10 +4,10 @@
 		:is-visible="showErrorSummary"
 		:items="[
 			{
-				validity: store.state.bankdata.validity.bankdata,
+				validity: bankDataValidity,
 				message: $t( 'donation_form_payment_bankdata_error' ),
-				focusElement: 'iban',
-				scrollElement: 'iban-scroll-target'
+				focusElement: 'account-number',
+				scrollElement: 'account-number-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.addressType,
@@ -70,10 +70,10 @@
 		:is-visible="showErrorSummary"
 		:items="[
 			{
-				validity: store.state.bankdata.validity.bankdata,
+				validity: bankDataValidity,
 				message: $t( 'donation_form_payment_bankdata_error' ),
-				focusElement: 'iban',
-				scrollElement: 'iban-scroll-target'
+				focusElement: 'account-number',
+				scrollElement: 'account-number-scroll-target'
 			},
 			{
 				validity: store.state.address.validity.companyName,
@@ -118,6 +118,12 @@
 		:is-visible="showErrorSummary"
 		:items="[
 			{
+				validity: bankDataValidity,
+				message: $t( 'donation_form_payment_bankdata_error' ),
+				focusElement: 'account-number',
+				scrollElement: 'account-number-scroll-target'
+			},
+			{
 				validity: store.state.address.validity.salutation,
 				message: $t( 'donation_form_salutation_error' ),
 				focusElement: 'email-salutation-0',
@@ -150,6 +156,8 @@
 import ErrorSummary from '@src/components/shared/validation_summary/ErrorSummary.vue';
 import { useStore } from 'vuex';
 import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
+import { computed } from 'vue';
+import { Validity } from '@src/view_models/Validity';
 
 interface Props {
 	showErrorSummary: boolean;
@@ -158,5 +166,6 @@ interface Props {
 
 defineProps<Props>();
 const store = useStore();
+const bankDataValidity = computed<Validity>( () => store.getters[ 'bankdata/bankDataIsInvalid' ] ? Validity.INVALID : Validity.VALID );
 
 </script>

--- a/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
+++ b/src/components/pages/donation_form/subpages/AddressPageDonationReceipt.vue
@@ -72,23 +72,45 @@
 					</template>
 				</RadioField>
 
-				<AddressFields
-					v-if="receiptNeeded"
-					:show-error="fieldErrors"
-					:form-data="formData"
-					:countries="countries"
-					:post-code-validation="addressValidationPatterns.postcode"
-					:country-was-restored="countryWasRestored"
-					@field-changed="onFieldChange"
-				/>
+				<FeatureToggle default-template="campaigns.address_field_order.legacy">
+					<template #campaigns.address_field_order.legacy>
+						<AddressFields
+							v-if="receiptNeeded"
+							:show-error="fieldErrors"
+							:form-data="formData"
+							:countries="countries"
+							:post-code-validation="addressValidationPatterns.postcode"
+							:country-was-restored="countryWasRestored"
+							@field-changed="onFieldChange"
+						/>
+						<AddressFormErrorSummaries
+							:show-error-summary="showErrorSummary"
+							:address-type="addressType"
+							:show-receipt-option-error="showReceiptOptionError"
+							:receipt-needed="receiptNeeded"
+						/>
+					</template>
+
+					<template #campaigns.address_field_order.new_order>
+						<AddressFieldsStreetAutocomplete
+							v-if="receiptNeeded"
+							:show-error="fieldErrors"
+							:form-data="formData"
+							:countries="countries"
+							:post-code-validation="addressValidationPatterns.postcode"
+							:country-was-restored="countryWasRestored"
+							@field-changed="onFieldChange"
+						/>
+						<AddressFormErrorSummariesStreetAutocomplete
+							:show-error-summary="showErrorSummary"
+							:address-type="addressType"
+							:show-receipt-option-error="showReceiptOptionError"
+							:receipt-needed="receiptNeeded"
+						/>
+					</template>
+				</FeatureToggle>
 
 			</AutofillHandler>
-
-			<AddressFormErrorSummaries
-				:show-error-summary="showErrorSummary"
-				:address-type="addressType"
-				:show-receipt-option-error="showReceiptOptionError"
-			/>
 
 			<FormSummary>
 				<template #summary-content>
@@ -159,6 +181,10 @@ import SubmitValues from '@src/components/pages/donation_form/SubmitValues.vue';
 import AddressFormErrorSummaries from '@src/components/pages/donation_form/DonationReceipt/AddressFormErrorSummaries.vue';
 import ScrollTarget from '@src/components/shared/ScrollTarget.vue';
 import BankFields from '@src/components/shared/BankFields.vue';
+import AddressFieldsStreetAutocomplete
+	from '@src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue';
+import AddressFormErrorSummariesStreetAutocomplete
+	from '@src/components/pages/donation_form/DonationReceipt/AddressFormErrorSummariesStreetAutocomplete.vue';
 
 interface Props {
 	assetsPath: string;

--- a/src/components/pages/donation_form/useAddressFormEventHandlers.ts
+++ b/src/components/pages/donation_form/useAddressFormEventHandlers.ts
@@ -60,11 +60,13 @@ export function useAddressFormEventHandlers(
 
 		if ( !store.getters[ 'address/requiredFieldsAreValid' ] ) {
 			addressDataIsValid.value = false;
-			return;
 		}
 
 		if ( isDirectDebit.value && !store.getters[ 'bankdata/bankDataIsValid' ] ) {
 			bankDataIsValid.value = false;
+		}
+
+		if ( !addressDataIsValid.value || !bankDataIsValid.value ) {
 			return;
 		}
 

--- a/src/components/pages/membership_form/subpages/PaymentPage.vue
+++ b/src/components/pages/membership_form/subpages/PaymentPage.vue
@@ -54,8 +54,8 @@
 				{
 					validity: store.state.bankdata.validity.bankdata,
 					message: $t( 'error_summary_iban' ),
-					focusElement: 'iban',
-					scrollElement: 'payment-form-iban-scroll-target'
+					focusElement: 'account-number',
+					scrollElement: 'account-number-scroll-target'
 				}
 			]"
 		/>

--- a/src/components/shared/BankFields.vue
+++ b/src/components/shared/BankFields.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="payment-bank-data-section">
-		<ScrollTarget target-id="iban-scroll-target"/>
+		<ScrollTarget target-id="account-number-scroll-target"/>
 		<DirectDebitField
 			v-model:account-number="accountNumber"
 			v-model:bank-code="bankCode"

--- a/tests/unit/components/pages/donation_form/AddressPage.spec.ts
+++ b/tests/unit/components/pages/donation_form/AddressPage.spec.ts
@@ -163,6 +163,51 @@ describe( 'AddressPage.vue', () => {
 		expect( wrapper.find( '.error-summary' ).exists() ).toBeFalsy();
 	} );
 
+	it.skip( 'shows and hides the error summary when payment data is invalid', async () => {
+		const { wrapper, store } = getWrapper();
+
+		await setPaymentType( store, 'BEZ' );
+
+		await wrapper.find( '#submit-btn' ).trigger( 'click' );
+		await nextTick();
+		await nextTick();
+
+		expect( wrapper.find( '.error-summary' ).exists() ).toBeTruthy();
+
+		await wrapper.find( '#addressType-0' ).trigger( 'change' );
+		await wrapper.find( '#person-salutation-0' ).trigger( 'change' );
+
+		await wrapper.find( '#person-first-name' ).setValue( 'first-name' );
+		await wrapper.find( '#person-first-name' ).trigger( 'blur' );
+
+		await wrapper.find( '#person-last-name' ).setValue( 'last-name' );
+		await wrapper.find( '#person-last-name' ).trigger( 'blur' );
+
+		await wrapper.find( '#person-street' ).setValue( 'street' );
+		await wrapper.find( '#person-street' ).trigger( 'blur' );
+
+		await wrapper.find( '#person-post-code' ).setValue( 'post-code' );
+		await wrapper.find( '#person-post-code' ).trigger( 'blur' );
+
+		await wrapper.find( '#person-city' ).setValue( 'city' );
+		await wrapper.find( '#person-city' ).trigger( 'blur' );
+
+		await wrapper.find( '#person-country' ).setValue( 'country' );
+		await wrapper.find( '#person-country' ).trigger( 'blur' );
+
+		await wrapper.find( '#person-email' ).setValue( 'joe@dolan.com' );
+		await wrapper.find( '#person-email' ).trigger( 'blur' );
+
+		expect( wrapper.find( '.error-summary' ).exists() ).toBeTruthy();
+
+		await wrapper.find( '#account-number' ).setValue( 'DE12500105170648489890' );
+		await wrapper.find( '#account-number' ).trigger( 'blur' );
+
+		await flushPromises();
+
+		expect( wrapper.find( '.error-summary' ).exists() ).toBeFalsy();
+	} );
+
 	it( 'updates full selected', async () => {
 		const { wrapper } = getWrapper();
 


### PR DESCRIPTION
We're about to do a test that needs both features
so now both address forms have both form orders

I also noticed that the error summaries weren't displaying
all the errors on the alternate form when the donor had
selected yes for receipt and not selected an address type.

Ticket: https://phabricator.wikimedia.org/T374216