### PR TITLE
Fix autocomplete error flash

### DIFF
--- a/src/components/shared/form_fields/CityAutocompleteField.vue
+++ b/src/components/shared/form_fields/CityAutocompleteField.vue
@@ -147,14 +147,20 @@ const onKeySubmit = () => {
 	city.value = activeCity.value;
 };
 
+let itemWasJustSelectedFromList = false;
+
 const onBlur = () => {
 	setTimeout( () => {
 		autocompleteIsActive.value = false;
+		if ( !itemWasJustSelectedFromList ) {
+			emit( 'field-changed' );
+		}
+		itemWasJustSelectedFromList = false;
 	}, 200 );
-	emit( 'field-changed' );
 };
 
 const onSelectItem = async ( newCity: string ) => {
+	itemWasJustSelectedFromList = true;
 	city.value = newCity;
 	await nextTick();
 	emit( 'field-changed' );

--- a/src/components/shared/form_fields/StreetAutocompleteField.vue
+++ b/src/components/shared/form_fields/StreetAutocompleteField.vue
@@ -182,14 +182,20 @@ const onStreetNameKeySubmit = () => {
 	streetNameModel.value = activeStreet.value;
 };
 
+let itemWasJustSelectedFromList = false;
+
 const onStreetNameBlur = () => {
 	setTimeout( () => {
 		autocompleteIsActive.value = false;
+		if ( !itemWasJustSelectedFromList ) {
+			emit( 'field-changed' );
+		}
+		itemWasJustSelectedFromList = false;
 	}, 200 );
-	emit( 'field-changed' );
 };
 
 const onSelectStreet = async ( newStreet: string ) => {
+	itemWasJustSelectedFromList = true;
 	streetNameModel.value = newStreet;
 	await nextTick();
 	emit( 'field-changed' );

--- a/tests/unit/components/pages/UpdateAddress.spec.ts
+++ b/tests/unit/components/pages/UpdateAddress.spec.ts
@@ -74,6 +74,8 @@ describe( 'UpdateAddress.vue', () => {
 	} );
 
 	it( 'shows and hides the error summary', async () => {
+		jest.useFakeTimers();
+
 		const store = createStore();
 		await store.dispatch( action( 'address', 'initializeAddress' ), { addressType: AddressTypeModel.COMPANY, fields: [] } );
 		const wrapper = getWrapper( store );
@@ -100,7 +102,11 @@ describe( 'UpdateAddress.vue', () => {
 		await country.setValue( 'country' );
 		await country.trigger( 'blur' );
 
+		await jest.runAllTimersAsync();
+
 		expect( wrapper.find( '.error-summary' ).exists() ).toBeFalsy();
+
+		jest.restoreAllMocks();
 	} );
 
 	it( 'redirects to the success page on successful submit', async () => {

--- a/tests/unit/components/pages/donation_form/AddressPage.spec.ts
+++ b/tests/unit/components/pages/donation_form/AddressPage.spec.ts
@@ -127,6 +127,8 @@ describe( 'AddressPage.vue', () => {
 	} );
 
 	it( 'shows and hides the error summary', async () => {
+		jest.useFakeTimers();
+
 		const { wrapper } = getWrapper();
 
 		await wrapper.find( '#submit-btn' ).trigger( 'click' );
@@ -159,7 +161,11 @@ describe( 'AddressPage.vue', () => {
 		await wrapper.find( '#person-email' ).setValue( 'joe@dolan.com' );
 		await wrapper.find( '#person-email' ).trigger( 'blur' );
 
+		await jest.runAllTimersAsync();
+
 		expect( wrapper.find( '.error-summary' ).exists() ).toBeFalsy();
+
+		jest.restoreAllMocks();
 	} );
 
 	it( 'updates full selected', async () => {

--- a/tests/unit/components/pages/membership_form/AddressPage.spec.ts
+++ b/tests/unit/components/pages/membership_form/AddressPage.spec.ts
@@ -76,6 +76,8 @@ describe( 'AddressPage.vue', () => {
 	} );
 
 	it( 'shows and hides the error summary', async () => {
+		jest.useFakeTimers();
+
 		const { wrapper } = getWrapper();
 
 		await wrapper.find( '#submit-btn' ).trigger( 'click' );
@@ -107,7 +109,11 @@ describe( 'AddressPage.vue', () => {
 		await wrapper.find( '#email' ).setValue( 'joe@dolan.com' );
 		await wrapper.find( '#email' ).trigger( 'blur' );
 
+		await jest.runAllTimersAsync();
+
 		expect( wrapper.find( '.error-summary' ).exists() ).toBeFalsy();
+
+		jest.restoreAllMocks();
 	} );
 
 	it( 'submits the form', async () => {

--- a/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
@@ -2,6 +2,7 @@ import { nextTick } from 'vue';
 import { mount, VueWrapper } from '@vue/test-utils';
 import CityAutocompleteField from '@src/components/shared/form_fields/CityAutocompleteField.vue';
 import { FakeCityAutocompleteResource } from '@test/unit/TestDoubles/FakeCityAutocompleteResource';
+import runAllTimersAsync = jest.runAllTimersAsync;
 
 const cityAutocompleteResource = new FakeCityAutocompleteResource();
 const placeholderKey = 'form_for_example';
@@ -87,21 +88,31 @@ describe( 'CityAutocompleteField.vue', () => {
 	} );
 
 	it( 'emits input event when an autocomplete item is selected', async () => {
+		jest.useFakeTimers();
+
 		const wrapper = getWrapper( '12345' );
 		await nextTick();
 		await nextTick();
 
 		await wrapper.find( '.dropdown-item:nth-child( 6 )' ).trigger( 'click' );
+		await runAllTimersAsync();
 
 		expect( wrapper.emitted( 'update:modelValue' )[ 0 ][ 0 ] ).toBe( 'Satan City' );
+		expect( wrapper.emitted( 'field-changed' ).length ).toBe( 1 );
+
+		jest.clearAllMocks();
 	} );
 
 	it( 'emits field changed event when text input is blurred', async () => {
+		jest.useFakeTimers();
+
 		const wrapper = getWrapper();
 
 		await wrapper.find<HTMLInputElement>( '#city' ).trigger( 'blur' );
+		await runAllTimersAsync();
 
 		expect( wrapper.emitted( 'field-changed' ).length ).toBe( 1 );
+		jest.clearAllMocks();
 	} );
 
 	it( 'emits field changed event when an autocomplete item is selected', async () => {

--- a/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
@@ -123,6 +123,38 @@ describe( 'CountryAutocompleteField.vue', () => {
 		expect( field.element.value ).toBe( countries[ 2 ].countryFullName );
 	} );
 
+	it( 'emits single field changed event when an autocomplete item is clicked', async () => {
+		jest.useFakeTimers();
+
+		const wrapper = getWrapper();
+		const field = wrapper.find<HTMLInputElement>( '#country' );
+
+		await field.trigger( 'focus' );
+		await wrapper.find( '.dropdown-item:nth-of-type(3)' ).trigger( 'click' );
+
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+
+		jest.clearAllMocks();
+	} );
+
+	it( 'emits field changed event when field is blurred', async () => {
+		jest.useFakeTimers();
+
+		const wrapper = getWrapper();
+		const field = wrapper.find<HTMLInputElement>( '#country' );
+
+		await field.trigger( 'focus' );
+		await field.trigger( 'blur' );
+
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+
+		jest.clearAllMocks();
+	} );
+
 	it( 'selects the input text on second focus when initialised with default', async () => {
 		const wrapper = getWrapper();
 		const field = wrapper.find<HTMLInputElement>( '#country' );

--- a/tests/unit/components/shared/form_fields/StreetAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/StreetAutocompleteField.spec.ts
@@ -119,6 +119,38 @@ describe( 'StreetAutocompleteField.vue', () => {
 		expect( wrapper.emitted( 'update:modelValue' )[ 1 ][ 0 ] ).toBe( `Cobblestone Way${ separator }42` );
 	} );
 
+	it( 'emits single field changed event when an autocomplete item is clicked', async () => {
+		jest.useFakeTimers();
+
+		const wrapper = getWrapper( '', '12345' );
+		const field = wrapper.find<HTMLInputElement>( '#street' );
+
+		await field.trigger( 'focus' );
+		await wrapper.find( '.dropdown-item:nth-child(3)' ).trigger( 'click' );
+
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+
+		jest.clearAllMocks();
+	} );
+
+	it( 'emits field changed event when field is blurred', async () => {
+		jest.useFakeTimers();
+
+		const wrapper = getWrapper();
+		const field = wrapper.find<HTMLInputElement>( '#street' );
+
+		await field.trigger( 'focus' );
+		await field.trigger( 'blur' );
+
+		await jest.runAllTimersAsync();
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+
+		jest.clearAllMocks();
+	} );
+
 	it( 'shows and hides the street number help text', async () => {
 		const wrapper = getWrapper();
 


### PR DESCRIPTION
When a donor clicks a city or street from the autocomplete
it flashes an error. This adds a check to stop it happening.