### PR TITLE
Improve testing on donation address forms

### DIFF
--- a/src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue
@@ -101,7 +101,6 @@
 import RadioField from '@src/components/shared/form_fields/RadioField.vue';
 import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
 import { useStore } from 'vuex';
-import { StoreKey } from '@src/store/donation_store';
 import { useAddressTypeModel } from '@src/components/pages/donation_form/DonationReceipt/useAddressTypeModel';
 import { AddressFormData, AddressValidity } from '@src/view_models/Address';
 import TextField from '@src/components/shared/form_fields/TextField.vue';
@@ -124,7 +123,7 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits( [ 'field-changed' ] );
 
-const store = useStore( StoreKey );
+const store = useStore();
 const addressType = useAddressTypeModel( store );
 
 const showAddressTypeError = computed( () => store.getters[ 'address/addressTypeIsInvalid' ] );

--- a/src/components/pages/donation_form/DonationReceipt/AddressFormErrorSummariesStreetAutocomplete.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFormErrorSummariesStreetAutocomplete.vue
@@ -229,7 +229,7 @@ interface Props {
 	showErrorSummary: boolean;
 	addressType: AddressTypeModel;
 	showReceiptOptionError: boolean;
-	receiptNeeded: boolean;
+	receiptNeeded?: boolean;
 }
 
 defineProps<Props>();

--- a/src/components/pages/donation_form/DonationReceipt/useAddressFormEventHandlers.ts
+++ b/src/components/pages/donation_form/DonationReceipt/useAddressFormEventHandlers.ts
@@ -46,11 +46,13 @@ export function useAddressFormEventHandlers(
 
 		if ( !store.getters[ 'address/requiredFieldsAreValid' ] ) {
 			addressDataIsValid.value = false;
-			return;
 		}
 
 		if ( isDirectDebit.value && !store.getters[ 'bankdata/bankDataIsValid' ] ) {
 			bankDataIsValid.value = false;
+		}
+
+		if ( !addressDataIsValid.value || !bankDataIsValid.value ) {
 			return;
 		}
 

--- a/src/components/pages/donation_form/StreetAutocomplete/PostalAddressFields.vue
+++ b/src/components/pages/donation_form/StreetAutocomplete/PostalAddressFields.vue
@@ -5,6 +5,7 @@
 		<CountryAutocompleteField
 			v-model="formData.country.value"
 			:input-id="`${fieldIdNamespace}country`"
+			:scroll-target-id="`${fieldIdNamespace}country-scroll-target`"
 			:countries="countries"
 			:was-restored="countryWasRestored"
 			:show-error="showError.country"

--- a/src/components/shared/validation_summary/ErrorSummary.vue
+++ b/src/components/shared/validation_summary/ErrorSummary.vue
@@ -16,6 +16,7 @@
 				<li :key="item.focusElement" v-if="item.validity === Validity.INVALID">
 					<a
 						:href="`#${ item.focusElement }`"
+						:data-scroll-element="item.scrollElement"
 						@click.prevent="() => onClickError( item.focusElement, item.scrollElement )"
 						@keydown.space="() => onClickError( item.focusElement, item.scrollElement )"
 						@keydown.enter="() => onClickError( item.focusElement, item.scrollElement )"

--- a/tests/unit/components/pages/donation_form/AddressPageDonationReceiptStreetAutoComplete.spec.ts
+++ b/tests/unit/components/pages/donation_form/AddressPageDonationReceiptStreetAutoComplete.spec.ts
@@ -39,7 +39,7 @@ const salutations: Salutation[] = [
 jest.mock( 'axios' );
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-describe( 'AddressPageDonationReceipt.vue', () => {
+describe( 'AddressPageDonationReceipt.vue (With Street Autocomplete)', () => {
 	const getWrapper = ( store: Store<any> = createStore() ): { wrapper: VueWrapper<any>, store: Store<any> } => {
 		const wrapper = mount( AddressPageDonationReceipt, {
 			props: {
@@ -63,7 +63,10 @@ describe( 'AddressPageDonationReceipt.vue', () => {
 					bankValidationResource: new FakeBankValidationResource(),
 				},
 				components: {
-					FeatureToggle: createFeatureToggle( [ 'campaigns.address_type_steps.preselect' ] ),
+					FeatureToggle: createFeatureToggle( [
+						'campaigns.address_type_steps.preselect',
+						'campaigns.address_field_order.new_order',
+					] ),
 				},
 			},
 		} );


### PR DESCRIPTION
We currently have 2 different address form tests running
which means we have 4 separate donation form flows to
manage. Each has their own group of error summaries and
the space for human error on them is large.

This adds tests to each of the donor flows that makes
sure the flow and error handling is working as expected on
each form.