### PR TITLE
Fix membership form bank data field

### DIFF
--- a/src/pages/membership_application.ts
+++ b/src/pages/membership_application.ts
@@ -62,11 +62,11 @@ dataPersister.initialize( persistenceItems ).then( () => {
 	);
 	initialFeeValues.setTypeFromAvailablePaymentTypes( pageData.applicationVars.paymentTypes );
 	const initialBankAccountData = {
-		accountNumber: initialFormValues.get( 'iban' ),
+		accountNumber: initialFormValues.get( 'iban' ) ?? '',
 		bankCode: '',
-		bankName: initialFormValues.get( 'bankname' ),
-		iban: initialFormValues.get( 'iban' ),
-		bic: initialFormValues.get( 'bic' ),
+		bankName: initialFormValues.get( 'bankname' ) ?? '',
+		iban: initialFormValues.get( 'iban' ) ?? '',
+		bic: initialFormValues.get( 'bic' ) ?? '',
 	};
 
 	// Combine the initial values (from app data and URL) with the values from the local storage.


### PR DESCRIPTION
When initial form data (from the application) did not contain bank
information (e.g. from a donation), the fields in the store were
automatically initialized with `undefined` instead of empty strings
which led to errors.

Ticket: https://phabricator.wikimedia.org/T374710
