### PR TITLE
Collapsible payment section

### DIFF
--- a/src/components/pages/DonationForm.vue
+++ b/src/components/pages/DonationForm.vue
@@ -3,7 +3,6 @@
 		<FeatureToggle default-template="campaigns.address_pages.legacy">
 			<template #campaigns.address_pages.legacy>
 					<PaymentSection
-						:assets-path="assetsPath"
 						:payment-amounts="paymentAmounts"
 						:payment-intervals="paymentIntervals"
 						:payment-types="paymentTypes"
@@ -23,7 +22,6 @@
 			</template>
 			<template #campaigns.address_pages.test_02>
 					<PaymentSection
-						:assets-path="assetsPath"
 						:payment-amounts="paymentAmounts"
 						:payment-intervals="paymentIntervals"
 						:payment-types="paymentTypes"

--- a/src/components/pages/donation_form/Payment.ts
+++ b/src/components/pages/donation_form/Payment.ts
@@ -1,0 +1,3 @@
+export type DisplaySection = 'amount' | 'interval' | 'paymentType';
+
+export type DisplaySectionCollection = [ DisplaySection, ...DisplaySection[] ];

--- a/src/components/pages/donation_form/Payment.vue
+++ b/src/components/pages/donation_form/Payment.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="payment-form">
-		<FormSection id="payment-form-amount">
+		<FormSection v-if="displaySections.includes( 'amount' )" id="payment-form-amount">
 			<ScrollTarget target-id="payment-form-amount-scroll-target"/>
 			<AmountField
 				v-model="amount"
@@ -11,7 +11,7 @@
 			/>
 		</FormSection>
 
-		<FormSection id="payment-form-interval">
+		<FormSection v-if="displaySections.includes( 'interval' )" id="payment-form-interval">
 			<RadioField
 				name="interval"
 				input-id="interval"
@@ -24,7 +24,7 @@
 			/>
 		</FormSection>
 
-		<FormSection id="payment-form-type">
+		<FormSection v-if="displaySections.includes( 'paymentType' )" id="payment-form-type">
 			<ScrollTarget target-id="payment-form-type-scroll-target"/>
 			<RadioField
 				name="paymentType"
@@ -67,14 +67,18 @@ import { Validity } from '@src/view_models/Validity';
 import FormSection from '@src/components/shared/form_elements/FormSection.vue';
 import ScrollTarget from '@src/components/shared/ScrollTarget.vue';
 import RadioFieldHelpText from '@src/components/shared/form_elements/RadioFieldTooltip.vue';
+import { DisplaySectionCollection } from '@src/components/pages/donation_form/Payment';
 
 interface Props {
 	paymentAmounts: number[];
 	paymentIntervals: number[];
 	paymentTypes: string[];
+	displaySections?: DisplaySectionCollection;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults( defineProps<Props>(), {
+	displaySections: () => [ 'amount', 'interval', 'paymentType' ],
+} );
 
 const store = useStore();
 const { t } = useI18n();

--- a/src/components/pages/donation_form/PaymentSummary.vue
+++ b/src/components/pages/donation_form/PaymentSummary.vue
@@ -4,7 +4,7 @@
 			<p v-html="props.paymentType ? summary : summaryWithoutPaymentType"/>
 		</div>
 		<div class="payment-summary-link">
-			<a href="#" @click.prevent="$emit( 'previous-page' )">{{ $t('donation_form_section_back') }}</a>
+			<a href="#" @click.prevent="$emit( 'show-payment-form' )">{{ $t('donation_form_section_back') }}</a>
 		</div>
 	</div>
 </template>

--- a/src/components/pages/donation_form/singlePageFormSections/PaymentSection.vue
+++ b/src/components/pages/donation_form/singlePageFormSections/PaymentSection.vue
@@ -7,7 +7,30 @@
 		<h1 id="donation-form-heading" class="form-title">{{ $t( 'donation_form_heading' ) }}</h1>
 		<h2 id="donation-form-subheading" class="form-subtitle">{{ $t( 'donation_form_payment_subheading' ) }}</h2>
 
+		<PaymentSummary
+			v-if="state === 'showSummary'"
+			@show-payment-form="state='showEntireForm'"
+			:amount="paymentSummary.amount"
+			:interval="paymentSummary.interval"
+			:payment-type="paymentSummary.paymentType"
+		/>
+
+		<div v-if="state === 'showSummaryAndPaymentType'" class="show-summary-and-payment-type">
+			<PaymentSummary
+				@show-payment-form="state='showEntireForm'"
+				:amount="paymentSummary.amount"
+				:interval="paymentSummary.interval"
+				:payment-type="paymentSummary.paymentType"
+			/>
+			<Payment
+				:payment-amounts="paymentAmounts"
+				:payment-intervals="paymentIntervals"
+				:payment-types="paymentTypes"
+			/>
+		</div>
+
 		<form
+			v-if="state === 'showEntireForm'"
 			name="laika-donation-payment"
 			class="payment-page"
 			ref="paymentForm"
@@ -24,12 +47,40 @@
 <script setup lang="ts">
 import Payment from '@src/components/pages/donation_form/Payment.vue';
 import ScrollTarget from '@src/components/shared/ScrollTarget.vue';
+import { ref } from 'vue';
+import PaymentSummary from '@src/components/pages/donation_form/PaymentSummary.vue';
+import { useStore } from 'vuex';
+import { usePaymentFunctions } from '@src/components/pages/donation_form/usePaymentFunctions';
+import { Validity } from '@src/view_models/Validity';
 
 interface Props {
 	paymentAmounts: number[];
 	paymentIntervals: number[];
 	paymentTypes: string[];
 }
+
 defineProps<Props>();
 
+type formStates = 'showEntireForm' | 'showSummary' | 'showSummaryAndPaymentType';
+const store = useStore();
+let initialFormState: formStates;
+
+if ( store.state.payment.validity.type === Validity.VALID && store.state.payment.validity.amount === Validity.VALID ) {
+	initialFormState = 'showSummary';
+} else if ( store.state.payment.validity.amount === Validity.VALID ) {
+	initialFormState = 'showSummaryAndPaymentType';
+} else {
+	initialFormState = 'showEntireForm';
+}
+
+const state = ref<formStates>( initialFormState );
+
+const { paymentSummary } = usePaymentFunctions( store );
+
 </script>
+<style>
+.show-summary-and-payment-type #payment-form-amount,
+.show-summary-and-payment-type #payment-form-interval {
+	display: none;
+}
+</style>

--- a/src/components/pages/donation_form/singlePageFormSections/PaymentSection.vue
+++ b/src/components/pages/donation_form/singlePageFormSections/PaymentSection.vue
@@ -26,7 +26,9 @@
 				:payment-amounts="paymentAmounts"
 				:payment-intervals="paymentIntervals"
 				:payment-types="paymentTypes"
+				:display-sections="[ 'paymentType' ]"
 			/>
+
 		</div>
 
 		<form
@@ -78,9 +80,3 @@ const state = ref<formStates>( initialFormState );
 const { paymentSummary } = usePaymentFunctions( store );
 
 </script>
-<style>
-.show-summary-and-payment-type #payment-form-amount,
-.show-summary-and-payment-type #payment-form-interval {
-	display: none;
-}
-</style>

--- a/tests/unit/components/pages/donation_form/Payment.spec.ts
+++ b/tests/unit/components/pages/donation_form/Payment.spec.ts
@@ -8,17 +8,19 @@ import AmountField from '@src/components/shared/form_fields/AmountField.vue';
 import { nextTick } from 'vue';
 import RadioField from '@src/components/shared/form_fields/RadioField.vue';
 import { AddressTypeModel } from '@src/view_models/AddressTypeModel';
+import { DisplaySection, DisplaySectionCollection } from '@src/components/pages/donation_form/Payment';
 
 describe( 'Payment.vue', () => {
 	let store: Store<any>;
 
-	const getWrapper = (): VueWrapper<any> => {
+	const getWrapper = ( displaySections: DisplaySectionCollection = [ 'amount', 'interval', 'paymentType' ] ): VueWrapper<any> => {
 		store = createStore();
 		return mount( Payment, {
 			props: {
 				paymentAmounts: [ 5 ],
 				paymentIntervals: [ 0, 1, 3, 6, 12 ],
 				paymentTypes: [ 'BEZ', 'PPL', 'UEB', 'SUB', 'BTC' ],
+				displaySections,
 			},
 			global: {
 				plugins: [ store ],
@@ -91,4 +93,15 @@ describe( 'Payment.vue', () => {
 		expect( wrapper.find( '.radio-field-tooltip' ).exists() ).toBe( false );
 	} );
 
+	it.each( [
+		[ 'amount', { amount: true, interval: false, paymentType: false } ],
+		[ 'interval', { amount: false, interval: true, paymentType: false } ],
+		[ 'paymentType', { amount: false, interval: false, paymentType: true } ],
+	] )( 'can render only one display section - %s ', ( sectionName: DisplaySection, elementExists: Record<string, boolean> ) => {
+		const wrapper = getWrapper( [ sectionName ] );
+
+		expect( wrapper.find( '#payment-form-amount' ).exists() ).toBe( elementExists.amount );
+		expect( wrapper.find( '#payment-form-interval' ).exists() ).toBe( elementExists.interval );
+		expect( wrapper.find( '#payment-form-type' ).exists() ).toBe( elementExists.paymentType );
+	} );
 } );

--- a/tests/unit/components/pages/donation_form/single_page_form/PaymentSection.spec.ts
+++ b/tests/unit/components/pages/donation_form/single_page_form/PaymentSection.spec.ts
@@ -1,0 +1,56 @@
+import { createStore } from '@src/store/donation_store';
+import { mount, VueWrapper } from '@vue/test-utils';
+import PaymentSummary from '@src/components/pages/donation_form/PaymentSummary.vue';
+import { action } from '@src/store/util';
+import PaymentSection from '@src/components/pages/donation_form/singlePageFormSections/PaymentSection.vue';
+import Payment from '@src/components/pages/donation_form/Payment.vue';
+
+const getWrapper = ( store: any ): VueWrapper<any> => {
+	return mount( PaymentSection, {
+		props: {
+			paymentAmounts: [ 10, 20, 30 ],
+			paymentIntervals: [ 1, 12 ],
+			paymentTypes: [ 'direct_debit', 'bank_transfer', 'credit_card' ],
+		},
+		global: {
+			plugins: [ store ],
+		},
+	} );
+};
+
+describe( 'PaymentSection.vue', () => {
+	it( 'should display the summary when the payment data in the store is valid', async () => {
+		const store = createStore();
+		await store.dispatch( action( 'payment', 'setAmount' ), '1000' );
+		await store.dispatch( action( 'payment', 'setInterval' ), 'monthly' );
+		await store.dispatch( action( 'payment', 'setType' ), 'credit_card' );
+		const wrapper = getWrapper( store );
+
+		expect( wrapper.findComponent( PaymentSummary ).exists() ).toBe( true );
+		expect( wrapper.find( 'form[name="laika-donation-payment"]' ).exists() ).toBe( false );
+	} );
+
+	it( 'should display summary and payment type selection when the payment type in store is invalid', async () => {
+		const store = createStore();
+		await store.dispatch( action( 'payment', 'setAmount' ), '1000' );
+		await store.dispatch( action( 'payment', 'setInterval' ), 'monthly' );
+		await store.dispatch( action( 'payment', 'setType' ), '' );
+		const wrapper = getWrapper( store );
+
+		expect( wrapper.findComponent( PaymentSummary ).exists() ).toBeTruthy();
+		expect( wrapper.findComponent( Payment ).exists() ).toBeTruthy();
+	} );
+
+	it( 'should display the full form when the store is empty', async () => {
+		const store = createStore();
+		await store.dispatch( action( 'payment', 'setAmount' ), '' );
+		await store.dispatch( action( 'payment', 'setInterval' ), '' );
+		await store.dispatch( action( 'payment', 'setType' ), '' );
+
+		const wrapper = getWrapper( store );
+
+		expect( wrapper.find( 'form[name="laika-donation-payment"]' ).exists() ).toBe( true );
+		expect( wrapper.findComponent( Payment ).exists() ).toBe( true );
+		expect( wrapper.findComponent( PaymentSummary ).exists() ).toBe( false );
+	} );
+} );

--- a/tests/unit/components/pages/donation_form/single_page_form/PaymentSection.spec.ts
+++ b/tests/unit/components/pages/donation_form/single_page_form/PaymentSection.spec.ts
@@ -37,8 +37,10 @@ describe( 'PaymentSection.vue', () => {
 		await store.dispatch( action( 'payment', 'setType' ), '' );
 		const wrapper = getWrapper( store );
 
+		const paymentComponent = wrapper.findComponent( Payment );
 		expect( wrapper.findComponent( PaymentSummary ).exists() ).toBeTruthy();
-		expect( wrapper.findComponent( Payment ).exists() ).toBeTruthy();
+		expect( paymentComponent.exists() ).toBeTruthy();
+		expect( paymentComponent.props().displaySections ).toEqual( [ 'paymentType' ] );
 	} );
 
 	it( 'should display the full form when the store is empty', async () => {


### PR DESCRIPTION
- Make PaymentSection collapsible
    
    - Add initial state to PaymentSection
    - Display `summary`, `summary with payment type` and `full form` depending on existing payment information
    - Connect store to PaymentSection

- Hide individual parts in Payment Components
    
    - Add property to Payment Component that displays the parts that should be shown, by default we show all parts
    - Show only payment type in PaymentSection with display state 'showSummaryAndPaymentType'

Ticket: https://phabricator.wikimedia.org/T368526