### PR TITLE
Harmonize npm start script with banner repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the frontend code for the WMDE Fundraising App.
 
 ## Running the development server
 
-	npm run serve
+	npm run dev
 	
 This will start the development server on port 7072. In your local
 development configuration for the Fundraising
@@ -47,7 +47,7 @@ The bundler will preserve all `url()` references as-is.
 
 On your local development machine, you must manually keep the contents of
 `dist` (of the fundraising-app-client project) and `web/skins/laika` (of
-the fundraising-app prject) in sync, otherwise the CSS references will be
+the fundraising-app project) in sync, otherwise the CSS references will be
 broken.
 
 ### Referencing resources in Vue

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "cross-env NODE_ENV=development webpack serve --host 0.0.0.0",
+	"start": "npm run dev",
+	"serve": "npm run dev",
+    "dev": "cross-env NODE_ENV=development webpack serve --host 0.0.0.0",
     "build": "cross-env NODE_ENV=production webpack",
     "test:unit": "jest --maxWorkers=1",
     "lint": "eslint --ext .ts,.vue src/ tests/",


### PR DESCRIPTION
Fundraising App and Banner repo NPM scripts now work the same:

- `npm run dev` as the canonical name to start the development server
  (When creating a new Vue project, the scaffolding will be `dev`
  see https://vuejs.org/guide/quick-start )
- `npm run start` as an alias for people who like to do "start"

This change should reduce mental friction, having to think about which
code base you're in.

We keep the `npm run serve` command for now make the transition easier,
but might remove it at some point.

Fixed a typo in the readme while updating the command line examples.
