### PR TITLE
Cleanup "scoped" modifiers and h2 styling

### DIFF
--- a/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFields.vue
@@ -151,7 +151,3 @@ const onCountryFieldChanged = ( country: Country | undefined ) => {
 };
 
 </script>
-
-<style scoped lang="scss">
-
-</style>

--- a/src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue
+++ b/src/components/pages/donation_form/DonationReceipt/AddressFieldsStreetAutocomplete.vue
@@ -143,7 +143,3 @@ const onCountryFieldChanged = ( country: Country | undefined ) => {
 };
 
 </script>
-
-<style scoped lang="scss">
-
-</style>

--- a/src/components/pages/donation_form/summary_content/PaymentSummaryAnonymous.vue
+++ b/src/components/pages/donation_form/summary_content/PaymentSummaryAnonymous.vue
@@ -31,7 +31,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/src/components/pages/donation_form/summary_content/PaymentSummaryCompany.vue
+++ b/src/components/pages/donation_form/summary_content/PaymentSummaryCompany.vue
@@ -55,7 +55,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/src/components/pages/donation_form/summary_content/PaymentSummaryCompanyWithContact.vue
+++ b/src/components/pages/donation_form/summary_content/PaymentSummaryCompanyWithContact.vue
@@ -55,7 +55,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/src/components/pages/donation_form/summary_content/PaymentSummaryEmail.vue
+++ b/src/components/pages/donation_form/summary_content/PaymentSummaryEmail.vue
@@ -54,7 +54,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/src/components/pages/donation_form/summary_content/PaymentSummaryPrivate.vue
+++ b/src/components/pages/donation_form/summary_content/PaymentSummaryPrivate.vue
@@ -64,7 +64,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/src/components/pages/donation_form/summary_content/PaymentSummaryUnset.vue
+++ b/src/components/pages/donation_form/summary_content/PaymentSummaryUnset.vue
@@ -31,7 +31,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/src/components/shared/ButtonLink.vue
+++ b/src/components/shared/ButtonLink.vue
@@ -27,7 +27,7 @@ defineEmits( [ 'click' ] );
 
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
 @use '@src/scss/settings/colors';
 
 .button-link {

--- a/src/components/shared/IbanFields.vue
+++ b/src/components/shared/IbanFields.vue
@@ -17,9 +17,9 @@
 			<ScrollTarget target-id="iban-calculator-scroll-target"/>
 
 			<div class="iban-calculator-content">
-				<h2 class="icon-title">
+				<h3 class="icon-title">
 					<BankIcon/> {{ $t( 'donation_form_iban_calculator_title' ) }}
-				</h2>
+				</h3>
 
 				<button class="iban-calculator-close" @click.prevent="showCalculator = false" aria-controls="iban-calculator">
 					<span class="is-sr-only">{{ $t( 'close' ) }}</span>
@@ -375,17 +375,17 @@ watch( () => store.state.bankdata.values.iban, ( newIban: string ) => {
 			}
 		}
 	}
-}
 
-h2.icon-title {
-	padding: map.get(units.$spacing, 'small') 0 0 1.5rem;
-	margin: 0 map.get(units.$spacing, 'small');
-	font-size: 18px;
-	line-height: 25px;
+	.icon-title {
+		padding: map.get(units.$spacing, 'small') 0 0 1.5rem;
+		margin: 0 map.get(units.$spacing, 'small');
+		font-size: 18px;
+		line-height: 25px;
 
-	svg {
-		float: left;
-		margin: 4px 0 0 -1.5rem;
+		svg {
+			float: left;
+			margin: 4px 0 0 -1.5rem;
+		}
 	}
 }
 


### PR DESCRIPTION
- the scoped modifier influences how css is compiled and should not be used
- Fix global h2 styling that accidentally slipped to a global scope (and make it more semantic by turning it into h3)

https://phabricator.wikimedia.org/T377833