### PR TITLE
Disable "no" option for direct debit

### DIFF
--- a/src/components/pages/donation_form/Payment.vue
+++ b/src/components/pages/donation_form/Payment.vue
@@ -106,6 +106,9 @@ const disabledPaymentTypes = computed<string[]>( () => {
 	if ( store.state.address.addressType === AddressTypeModel.ANON ) {
 		disabledTypes.push( 'BEZ' );
 	}
+	if ( store.state.address.addressType === AddressTypeModel.EMAIL ) {
+		disabledTypes.push( 'BEZ' );
+	}
 	if ( store.state.payment.values.interval !== '0' ) {
 		disabledTypes.push( 'SUB' );
 	}

--- a/src/components/shared/form_elements/RadioFieldTooltip.vue
+++ b/src/components/shared/form_elements/RadioFieldTooltip.vue
@@ -34,6 +34,7 @@ defineProps<Props>();
 	background: colors.$white;
 
 	&-text {
+		z-index: 10;
 		position: absolute;
 		display: block;
 		visibility: hidden;

--- a/tests/unit/components/pages/donation_form/DonationFormReceipt.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationFormReceipt.spec.ts
@@ -445,10 +445,7 @@ describe( 'DonationFormReciept.vue', () => {
 		submitForm.element.submit = jest.fn();
 
 		await wrapper.find( 'input[name="amount"][value="500"]' ).trigger( 'change' );
-		await wrapper.find( 'input[name="paymentType"][value="BEZ"]' ).trigger( 'change' );
-
-		await wrapper.find( '#iban' ).setValue( IBAN );
-		await wrapper.find( '#iban' ).trigger( 'blur' );
+		await wrapper.find( 'input[name="paymentType"][value="UEB"]' ).trigger( 'change' );
 
 		await wrapper.find( 'input[name="salutation"][value="Mr"]' ).trigger( 'change' );
 

--- a/tests/unit/components/pages/donation_form/FormSections/PersonalDataSectionDonationReceipt.spec.ts
+++ b/tests/unit/components/pages/donation_form/FormSections/PersonalDataSectionDonationReceipt.spec.ts
@@ -107,4 +107,22 @@ describe( 'PersonalDataSectionDonationReceipt.vue', () => {
 
 		expect( wrapper.find( '.address-section' ).exists() ).toBeTruthy();
 	} );
+
+	it( 'disables NO option on question for full address and shows info icon', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.setProps( { isDirectDebitPayment: true } );
+		await nextTick();
+
+		expect( wrapper.find( '.radio-field-tooltip' ).isVisible() ).toBe( true );
+	} );
+
+	it( 'NO option is not disabled when direct debit is not selected', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.setProps( { isDirectDebitPayment: false } );
+		await nextTick();
+
+		expect( wrapper.find( '.radio-field-tooltip' ).exists() ).toBe( false );
+	} );
 } );

--- a/tests/unit/components/pages/donation_form/Payment.spec.ts
+++ b/tests/unit/components/pages/donation_form/Payment.spec.ts
@@ -85,10 +85,18 @@ describe( 'Payment.vue', () => {
 		expect( wrapper.find( '.radio-field-tooltip' ).isVisible() ).toBe( true );
 	} );
 
-	it( 'does not render tooltip hint if address type is something different than Anonymous', async () => {
+	it( 'renders tooltip hint if address type is Email-Only', async () => {
 		const wrapper = getWrapper();
 
 		await store.dispatch( action( 'address', 'setAddressType' ), AddressTypeModel.EMAIL );
+
+		expect( wrapper.find( '.radio-field-tooltip' ).isVisible() ).toBe( true );
+	} );
+
+	it( 'does not render tooltip hint if address type is something different than Anonymous or Email-only', async () => {
+		const wrapper = getWrapper();
+
+		await store.dispatch( action( 'address', 'setAddressType' ), AddressTypeModel.COMPANY );
 
 		expect( wrapper.find( '.radio-field-tooltip' ).exists() ).toBe( false );
 	} );


### PR DESCRIPTION
- we demand a full address from users when they select direct debit as a payment option. when asking about if they want to have a receipt, they need to say yes (give address), so we have to disable the "no" option.
- respectively the DirectDebit option should be disabled when "no" got selected first

- lift the tooltip message above other neighboring elements that updated dynamically

this fixes https://phabricator.wikimedia.org/T379565