### PR TITLE
Give tooltip better visibility

### DIFF
--- a/src/components/shared/form_elements/RadioFieldTooltip.vue
+++ b/src/components/shared/form_elements/RadioFieldTooltip.vue
@@ -32,6 +32,7 @@ defineProps<Props>();
 	height: 16px;
 	width: 17px;
 	background: colors.$white;
+	z-index: 99;
 
 	&-text {
 		position: absolute;


### PR DESCRIPTION
- gives the tooltip feature a higher z-index to prevent other dynamically updating neighbour elements clashing with it visually
- is supposed to solve:
![Bildschirmfoto von 2024-11-25 14-44-45](https://github.com/user-attachments/assets/bf0309ae-e93e-494d-904b-cbcf29bc94ba)
