### PR TITLE
Add exported message to membership confirmation

### DIFF
--- a/src/Domain/Membership/MembershipApplication.ts
+++ b/src/Domain/Membership/MembershipApplication.ts
@@ -6,4 +6,5 @@ export interface MembershipApplication {
 	membershipType: MembershipType;
 	paymentType: string;
 	incentives: string[];
+	isExported: boolean;
 }

--- a/src/components/pages/MembershipConfirmation.vue
+++ b/src/components/pages/MembershipConfirmation.vue
@@ -10,7 +10,7 @@
 			<p v-if="showBankTransferContent">{{ $t( 'membership_confirmation_success_text_bank_transfer' ) }}</p>
 		</div>
 
-		<div class="membership-confirmation-card">
+		<div class="membership-confirmation-card" v-if="!confirmationData.membershipApplication.isExported">
 			<h2 class="icon-title"><SuccessIcon/> {{ $t( 'membership_confirmation_address_head' ) }}</h2>
 			<p>
 				<template v-if="address.applicantType === 'person'">{{ salutation }}{{ address.fullName }}</template>
@@ -21,6 +21,14 @@
 				{{ countryName }}
 			</p>
 			<p>{{ address.email }}</p>
+		</div>
+		<div class="membership-confirmation-card" v-else>
+			<h2 class="icon-title">
+				<WarningIcon/> {{ $t( 'membership_confirmation_exported_title' ) }}
+			</h2>
+			<p>
+				{{ $t( 'membership_confirmation_exported_content' ) }}
+			</p>
 		</div>
 
 		<membership-survey
@@ -43,6 +51,7 @@ import { computed } from 'vue';
 import { YearlyMembershipFee } from '@src/view_models/MembershipFee';
 import { useI18n } from 'vue-i18n';
 import SuccessIcon from '@src/components/shared/icons/SuccessIcon.vue';
+import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
 
 interface Props {
 	confirmationData: MembershipApplicationConfirmationData;

--- a/tests/unit/components/pages/MembershipConfirmation.spec.ts
+++ b/tests/unit/components/pages/MembershipConfirmation.spec.ts
@@ -36,6 +36,7 @@ const monthlyApplication: MembershipApplication = {
 	paymentIntervalInMonths: 1,
 	paymentType: 'BEZ',
 	incentives: [],
+	isExported: false,
 };
 
 const yearlyApplication: MembershipApplication = {
@@ -125,6 +126,13 @@ describe( 'MembershipConfirmation.vue', () => {
 		const wrapper = getWrapper( { ...yearlyApplication, paymentType: 'UEB' }, privateAddress );
 
 		expect( wrapper.text() ).toContain( 'membership_confirmation_success_text_bank_transfer' );
+	} );
+
+	test( 'tells the member that their address was anonymised', () => {
+		const wrapper = getWrapper( { ...monthlyApplication, isExported: true }, privateAddress );
+
+		expect( wrapper.text() ).toContain( 'membership_confirmation_exported_title' );
+		expect( wrapper.text() ).toContain( 'membership_confirmation_exported_content' );
 	} );
 
 	test( 'shows the survey tile if survey link language item is not empty', () => {

--- a/tests/unit/components/pages/membership_confirmation/MembershipSummary.spec.ts
+++ b/tests/unit/components/pages/membership_confirmation/MembershipSummary.spec.ts
@@ -35,6 +35,7 @@ const monthlyApplication: MembershipApplication = {
 	paymentIntervalInMonths: 1,
 	paymentType: 'BEZ',
 	incentives: [],
+	isExported: false,
 };
 
 const quarterlyApplication: MembershipApplication = {


### PR DESCRIPTION
When a membership has been exported and the member visits the confirmation page it will no longer throw and error, but will display a message to the member that their data has been processed and anonymised.

Ticket: https://phabricator.wikimedia.org/T316201