### PR TITLE
Validate invalid text fields in input

### DIFF
--- a/src/components/shared/form_elements/TextFormInput.vue
+++ b/src/components/shared/form_elements/TextFormInput.vue
@@ -18,6 +18,7 @@
 			:aria-autocomplete="ariaAutocomplete"
 			@blur="onBlur"
 			@focus="onFocus"
+			@input="onInput"
 		/>
 		<textarea
 			v-if="inputType === 'textarea'"
@@ -35,6 +36,7 @@
 			:aria-describedby="ariaDescribedby"
 			@blur="onBlur"
 			@focus="onFocus"
+			@input="onInput"
 		/>
 		<span v-if="hasError" class="icon is-right has-text-danger">
 			<i class="mdi mdi-alert-circle mdi-24px"></i>
@@ -71,12 +73,13 @@ const props = withDefaults( defineProps<Props>(), {
 	disabled: false,
 	required: false,
 } );
-const emit = defineEmits( [ 'update:modelValue', 'focus', 'blur' ] );
+const emit = defineEmits( [ 'update:modelValue', 'focus', 'blur', 'input' ] );
 
 const inputModel = useInputModel<string | number>( () => props.modelValue, props.modelValue, emit );
 
 const onFocus = ( event: Event ): void => emit( 'focus', event );
 const onBlur = ( event: Event ): void => emit( 'blur', event );
+const onInput = ( event: Event ): void => emit( 'input', event );
 
 </script>
 

--- a/src/components/shared/form_fields/CityAutocompleteField.vue
+++ b/src/components/shared/form_fields/CityAutocompleteField.vue
@@ -12,6 +12,7 @@
 				:input-id="inputId"
 				@focus="onFocus"
 				@blur="onBlur"
+				@input="onInput"
 				@keydown="onKeydown"
 				@keydown.up.prevent="onKeyArrows( 'up' )"
 				@keydown.down.prevent="onKeyArrows( 'down' )"
@@ -143,6 +144,12 @@ const onKeySubmit = () => {
 };
 
 let itemWasJustSelectedFromList = false;
+
+const onInput = (): void => {
+	if ( props.showError ) {
+		emit( 'field-changed' );
+	}
+};
 
 const onBlur = () => {
 	setTimeout( () => {

--- a/src/components/shared/form_fields/CountryAutocompleteField.vue
+++ b/src/components/shared/form_fields/CountryAutocompleteField.vue
@@ -12,6 +12,7 @@
 				name="countrySelector"
 				@focus="onFocus"
 				@blur="() => onBlur( country )"
+				@input="onInput"
 				@keydown="onKeydown"
 				@keydown.up.prevent="onKeyArrows('up')"
 				@keydown.down.prevent="onKeyArrows('down')"
@@ -154,6 +155,13 @@ const onKeySubmit = () => {
 };
 
 let itemWasJustSelectedFromList = false;
+
+const onInput = async (): Promise<void> => {
+	if ( props.showError ) {
+		await nextTick();
+		emit( 'field-changed', country.value );
+	}
+};
 
 const onBlur = ( selectedCountry: Country ) => {
 	setTimeout( () => {

--- a/src/components/shared/form_fields/EmailField.vue
+++ b/src/components/shared/form_fields/EmailField.vue
@@ -13,6 +13,7 @@
 			:aria-describedby="ariaDescribedby"
 			@update:modelValue="onUpdateModel"
 			@blur="$emit('field-changed', 'email')"
+			@input="onInput"
 		/>
 		<span v-if="suggestedProvider"
 				class="help is-clickable"
@@ -56,6 +57,12 @@ const ariaDescribedby = useAriaDescribedby(
 	`${( props.inputId ?? 'email' )}-error`,
 	computed<boolean>( () => props.showError )
 );
+
+const onInput = (): void => {
+	if ( props.showError ) {
+		emit( 'field-changed', 'email' );
+	}
+};
 
 const onUpdateModel = ( newValue: string ): void => {
 	emit( 'update:modelValue', newValue );

--- a/src/components/shared/form_fields/IbanField.vue
+++ b/src/components/shared/form_fields/IbanField.vue
@@ -99,6 +99,10 @@ const onInput = async (): Promise<void> => {
 	}
 
 	emit( 'update:modelValue', fieldModel.value );
+
+	if ( props.showError ) {
+		emit( 'field-changed', 'iban' );
+	}
 };
 
 const onBlur = (): void => {

--- a/src/components/shared/form_fields/StreetAutocompleteField.vue
+++ b/src/components/shared/form_fields/StreetAutocompleteField.vue
@@ -12,6 +12,7 @@
 				:input-id="inputIdStreetName"
 				@focus="onStreetNameFocus"
 				@blur="onStreetNameBlur"
+				@input="onStreetNameInput"
 				@keydown="onStreetNameKeydown"
 				@keydown.up.prevent="onStreetNameKeyArrows( 'up' )"
 				@keydown.down.prevent="onStreetNameKeyArrows( 'down' )"
@@ -187,6 +188,12 @@ const onStreetNameBlur = () => {
 		}
 		itemWasJustSelectedFromList = false;
 	}, 200 );
+};
+
+const onStreetNameInput = (): void => {
+	if ( props.showError ) {
+		emit( 'field-changed' );
+	}
 };
 
 const onSelectStreet = async ( newStreet: string ) => {

--- a/src/components/shared/form_fields/TextField.vue
+++ b/src/components/shared/form_fields/TextField.vue
@@ -20,6 +20,7 @@
 			:autofocus="autofocus"
 			:aria-describedby="ariaDescribedby"
 			@blur="$emit('field-changed', name )"
+			@input="onInput"
 			@update:modelValue="onUpdateModel"
 		/>
 		<span v-if="showError" class="help is-danger" :id="`${inputId}-error`">{{ errorMessage }}</span>
@@ -67,6 +68,12 @@ const ariaDescribedby = useAriaDescribedby(
 	`${props.inputId}-error`,
 	computed<boolean>( () => props.showError )
 );
+
+const onInput = (): void => {
+	if ( props.showError ) {
+		emit( 'field-changed', props.name );
+	}
+};
 
 const onUpdateModel = ( newValue: string | number ): void => {
 	emit( 'update:modelValue', newValue );

--- a/tests/unit/components/shared/form_elements/TextFormInput.spec.ts
+++ b/tests/unit/components/shared/form_elements/TextFormInput.spec.ts
@@ -63,6 +63,7 @@ describe( 'TextFormInput.vue', () => {
 		expect( wrapper.emitted( 'focus' ).length ).toStrictEqual( 1 );
 		expect( wrapper.emitted( 'update:modelValue' ).length ).toStrictEqual( 1 );
 		expect( wrapper.emitted( 'update:modelValue' )[ 0 ][ 0 ] ).toStrictEqual( 'Chewy' );
+		expect( wrapper.emitted( 'input' ).length ).toStrictEqual( 1 );
 		expect( wrapper.emitted( 'blur' ).length ).toStrictEqual( 1 );
 	} );
 

--- a/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CityAutocompleteField.spec.ts
@@ -248,4 +248,17 @@ describe( 'CityAutocompleteField.vue', () => {
 
 		expect( scrollElement.scrollIntoView ).not.toHaveBeenCalled();
 	} );
+
+	it( 'revalidates on input when invalid', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( '#city' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ) ).toBeUndefined();
+
+		await wrapper.setProps( { showError: true } );
+		await wrapper.find( '#city' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+	} );
 } );

--- a/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/CountryAutocompleteField.spec.ts
@@ -305,4 +305,17 @@ describe( 'CountryAutocompleteField.vue', () => {
 
 		expect( scrollElement.scrollIntoView ).not.toHaveBeenCalled();
 	} );
+
+	it( 'revalidates on input when invalid', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( '#country' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ) ).toBeUndefined();
+
+		await wrapper.setProps( { showError: true } );
+		await wrapper.find( '#country' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+	} );
 } );

--- a/tests/unit/components/shared/form_fields/EmailField.spec.ts
+++ b/tests/unit/components/shared/form_fields/EmailField.spec.ts
@@ -105,4 +105,18 @@ describe( 'EmailField.vue', () => {
 
 		expect( wrapper.find( '#email' ).attributes( 'aria-describedby' ) ).toStrictEqual( 'help-text email-error' );
 	} );
+
+	it( 'revalidates on input when invalid', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( 'input' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ) ).toBeUndefined();
+
+		await wrapper.setProps( { showError: true } );
+		await wrapper.find( 'input' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+		expect( wrapper.emitted( 'field-changed' )[ 0 ][ 0 ] ).toStrictEqual( 'email' );
+	} );
 } );

--- a/tests/unit/components/shared/form_fields/IbanField.spec.ts
+++ b/tests/unit/components/shared/form_fields/IbanField.spec.ts
@@ -117,4 +117,18 @@ describe( 'IbanField.vue', () => {
 		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
 		expect( wrapper.emitted( 'field-changed' )[ 0 ] ).toStrictEqual( [ 'iban' ] );
 	} );
+
+	it( 'revalidates on input when invalid', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( '#iban' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ) ).toBeUndefined();
+
+		await wrapper.setProps( { showError: true } );
+		await wrapper.find( '#iban' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+		expect( wrapper.emitted( 'field-changed' )[ 0 ][ 0 ] ).toStrictEqual( 'iban' );
+	} );
 } );

--- a/tests/unit/components/shared/form_fields/StreetAutocompleteField.spec.ts
+++ b/tests/unit/components/shared/form_fields/StreetAutocompleteField.spec.ts
@@ -282,4 +282,17 @@ describe( 'StreetAutocompleteField.vue', () => {
 
 		expect( scrollElement.scrollIntoView ).not.toHaveBeenCalled();
 	} );
+
+	it( 'revalidates on input when invalid', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( '#street' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ) ).toBeUndefined();
+
+		await wrapper.setProps( { showError: true } );
+		await wrapper.find( '#street' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+	} );
 } );

--- a/tests/unit/components/shared/form_fields/TextField.spec.ts
+++ b/tests/unit/components/shared/form_fields/TextField.spec.ts
@@ -77,4 +77,18 @@ describe( 'TextField.vue', () => {
 		expect( wrapper.find( '#textField' ).attributes( 'aria-describedby' ) ).toStrictEqual( 'textField-help-text textField-error' );
 	} );
 
+	it( 'revalidates on input when invalid', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.find( 'input' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ) ).toBeUndefined();
+
+		await wrapper.setProps( { showError: true } );
+		await wrapper.find( 'input' ).trigger( 'input' );
+
+		expect( wrapper.emitted( 'field-changed' ).length ).toStrictEqual( 1 );
+		expect( wrapper.emitted( 'field-changed' )[ 0 ][ 0 ] ).toStrictEqual( 'textField' );
+	} );
+
 } );


### PR DESCRIPTION
We had reports from some donors that they get confused
when they fix a field that had been previously marked
invalid, because it stays invalid until they blur it.

Validating a field on every input is annoying to the
donors so we shouldn't do that.

This strikes a balance by making the validation check
run on input only when the field is invalid, and once
it becomes valid again then stops. It will then
validate again when they blur the field.

Ticket: https://phabricator.wikimedia.org/T390039