### PR TITLE
Add an icon to target blank links

### DIFF
--- a/src/components/pages/UseOfFunds.vue
+++ b/src/components/pages/UseOfFunds.vue
@@ -50,7 +50,7 @@
 						</span>
 						<span class="use-of-funds-companies-link">
 							<a v-if="company.link !== ''" class="company_budgets__citation_link" :href="company.link" target="_blank">
-								{{ company.linkText }}
+								{{ company.linkText }} <ExternalLink/>
 							</a>
 							<span v-else>&nbsp;</span>
 						</span>
@@ -72,6 +72,7 @@ import BenefitsIcon from '@src/components/pages/use_of_funds/BenefitsIcon.vue';
 import { computed } from 'vue';
 import CallToAction from '@src/components/pages/use_of_funds/CallToAction.vue';
 import ChevronDown from '@src/components/shared/icons/ChevronDown.vue';
+import ExternalLink from '@src/components/shared/icons/ExternalLink.vue';
 
 interface Props {
 	content: UseOfFundsContent;
@@ -348,9 +349,10 @@ const highestBudget = computed( () => props.content.revenueComparison.companies.
 			white-space: nowrap;
 		}
 		&-link {
-			flex: 0 0 50px;
+			flex: 0 0 60px;
 			font-size: 14px;
 			text-align: right;
+			white-space: nowrap;
 		}
 		&-budget-line {
 			background: var( --budget-line-background );

--- a/src/components/pages/donation_confirmation/DonationSurvey.vue
+++ b/src/components/pages/donation_confirmation/DonationSurvey.vue
@@ -2,12 +2,13 @@
 	<div class="donation-confirmation-card donation-survey">
 		<h2 class="icon-title"><donor-icon/> {{ $t( 'donation_confirmation_survey_title' ) }}</h2>
 		<p>{{ $t( 'donation_confirmation_survey_content' ) }}</p>
-		<p><a target="_blank" :href="$t( 'donation_confirmation_survey_link', { tracking: tracking } )">{{ $t( 'donation_confirmation_survey_link_text' ) }}</a></p>
+		<p><a target="_blank" :href="$t( 'donation_confirmation_survey_link', { tracking: tracking } )">{{ $t( 'donation_confirmation_survey_link_text' ) }} <ExternalLink/></a></p>
 	</div>
 </template>
 
 <script setup lang="ts">
 import DonorIcon from '@src/components/shared/icons/DonorIcon.vue';
+import ExternalLink from '@src/components/shared/icons/ExternalLink.vue';
 
 interface Props {
 	tracking: string;

--- a/src/components/pages/membership_confirmation/MembershipSurvey.vue
+++ b/src/components/pages/membership_confirmation/MembershipSurvey.vue
@@ -2,12 +2,13 @@
 	<div class="membership-confirmation-card membership-survey">
 		<h2 class="icon-title"><donor-icon/> {{ $t( 'membership_confirmation_survey_title' ) }}</h2>
 		<p>{{ $t( 'membership_confirmation_survey_content' ) }}</p>
-		<p><a target="_blank" :href="$t( 'membership_confirmation_survey_link', { tracking: tracking } )">{{ $t( 'membership_confirmation_survey_link_text' ) }}</a></p>
+		<p><a target="_blank" :href="$t( 'membership_confirmation_survey_link', { tracking: tracking } )">{{ $t( 'membership_confirmation_survey_link_text' ) }} <ExternalLink/></a></p>
 	</div>
 </template>
 
 <script setup lang="ts">
 import DonorIcon from '@src/components/shared/icons/DonorIcon.vue';
+import ExternalLink from '@src/components/shared/icons/ExternalLink.vue';
 
 interface Props {
 	tracking: string;

--- a/src/components/shared/icons/ExternalLink.vue
+++ b/src/components/shared/icons/ExternalLink.vue
@@ -1,0 +1,8 @@
+<template>
+	<span class="is-sr-only">({{ $t( 'opens_in_new_tab' ) }})</span>
+	<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+		<path d="M4 2.5H0.5V9.5H7.5V6" stroke="currentcolor"></path>
+		<path d="M3.5 6.5L9 1" stroke="currentcolor"></path>
+		<path d="M5 0.5H9.5V5" stroke="currentcolor"></path>
+	</svg>
+</template>


### PR DESCRIPTION
Links that open new tabs should be identifiable to donors:
https://www.w3.org/WAI/WCAG22/Techniques/general/G201

This adds a small icon and some screen reader
text to do just that.

Ticket: https://phabricator.wikimedia.org/T391429