### PR TITLE
Add underline to links

### DIFF
--- a/src/components/layout/AppFooter.vue
+++ b/src/components/layout/AppFooter.vue
@@ -113,6 +113,7 @@ const footerMenu = [
 				color: colors.$black;
 				display: block;
 				position: relative;
+				text-decoration: none;
 				top:50%;
 				transform: translateY(-50%);
 

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -122,6 +122,10 @@ $side-width: 80px;
 			}
 		}
 
+		a {
+			text-decoration: none;
+		}
+
 		&.active {
 			display: flex;
 		}

--- a/src/components/pages/use_of_funds/CallToAction.vue
+++ b/src/components/pages/use_of_funds/CallToAction.vue
@@ -38,6 +38,8 @@ defineProps<Props>();
 		font-weight: bold;
 		cursor: pointer;
 		display: inline-block;
+		text-decoration: none;
+
 		&:hover,
 		&:focus {
 			color: var( --call-to-action-color );

--- a/src/components/shared/form_elements/FormButton.vue
+++ b/src/components/shared/form_elements/FormButton.vue
@@ -50,6 +50,7 @@ $hover-color: color.adjust( colors.$primary, $lightness: -5% );
 	width: 240px;
 	cursor: pointer;
 	transition: background-color 200ms global.$easing, color 200ms global.$easing;
+	text-decoration: none;
 
 	&:hover,
 	&:focus {

--- a/src/scss/overrides.scss
+++ b/src/scss/overrides.scss
@@ -198,6 +198,7 @@ button.is-low {
 	}
 }
 
+a,
 a:hover,
 a:focus {
 	text-decoration: underline;


### PR DESCRIPTION
Links need to be distinguishable in greyscale:
https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html

This adds underlines to all our "in content" links
and adjust the styles of the header/footer/button links.

Ticket: https://phabricator.wikimedia.org/T391429