### PR TITLE
Add reduced motion to animations

### DIFF
--- a/src/components/layout/LocaleSelector.vue
+++ b/src/components/layout/LocaleSelector.vue
@@ -156,6 +156,10 @@ useDetectOutsideClick( localeSelectorRef, handleLocaleItemBlur );
 		border-radius: 2px;
 		box-shadow: 1px 2px 3px rgba( 0, 0, 0, 0.1);
 		transition: opacity 200ms global.$easing, visibility 200ms global.$easing;
+
+		@media (prefers-reduced-motion) {
+			transition-duration: 0ms;
+		}
 	}
 
 	.radio-form-input {

--- a/src/components/pages/donation_form/SubPages/DonationForm.vue
+++ b/src/components/pages/donation_form/SubPages/DonationForm.vue
@@ -130,7 +130,7 @@ const { submit, submitValuesForm, showErrorSummary } = useDonationFormSubmitHand
 const scrollToPaymentSection = () => {
 	const scrollIntoViewElement = document.getElementById( 'payment-section-top-scroll-target' );
 	if ( scrollIntoViewElement ) {
-		scrollIntoViewElement.scrollIntoView( { behavior: 'smooth' } );
+		scrollIntoViewElement.scrollIntoView( { behavior: 'auto' } );
 	}
 };
 

--- a/src/components/pages/donation_form/SubPages/DonationFormAnonymousChoice.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormAnonymousChoice.vue
@@ -135,7 +135,7 @@ const { submit, submitValuesForm, showErrorSummary } = useDonationFormSubmitHand
 const scrollToPaymentSection = () => {
 	const scrollIntoViewElement = document.getElementById( 'payment-section-top-scroll-target' );
 	if ( scrollIntoViewElement ) {
-		scrollIntoViewElement.scrollIntoView( { behavior: 'smooth' } );
+		scrollIntoViewElement.scrollIntoView( { behavior: 'auto' } );
 	}
 };
 

--- a/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
@@ -136,7 +136,7 @@ const { submit, submitValuesForm, showErrorSummary } = useDonationFormSubmitHand
 const scrollToPaymentSection = () => {
 	const scrollIntoViewElement = document.getElementById( 'payment-section-top-scroll-target' );
 	if ( scrollIntoViewElement ) {
-		scrollIntoViewElement.scrollIntoView( { behavior: 'smooth' } );
+		scrollIntoViewElement.scrollIntoView( { behavior: 'auto' } );
 	}
 };
 

--- a/src/components/shared/ModalDialogue.vue
+++ b/src/components/shared/ModalDialogue.vue
@@ -114,8 +114,16 @@ $title-height-large: map.get( units.$spacing, 'xxx-large' );
 	overflow: hidden;
 	animation: fade-out 500ms global.$easing;
 
+	@media (prefers-reduced-motion) {
+		animation-duration: 0ms;
+	}
+
 	&[open] {
 		animation: fade-in 500ms global.$easing;
+
+		@media (prefers-reduced-motion) {
+			animation-duration: 0ms;
+		}
 	}
 
 	&::backdrop {

--- a/src/components/shared/form_fields/useAutocompleteScrollIntoViewOnFocus.ts
+++ b/src/components/shared/form_fields/useAutocompleteScrollIntoViewOnFocus.ts
@@ -9,7 +9,7 @@ export function useAutocompleteScrollIntoViewOnFocus( target: string, maxWidth: 
 
 		const scrollIntoViewElement = document.getElementById( target );
 		if ( scrollIntoViewElement ) {
-			scrollIntoViewElement.scrollIntoView( { behavior: 'smooth' } );
+			scrollIntoViewElement.scrollIntoView( { behavior: 'auto' } );
 		}
 	};
 }

--- a/src/components/shared/validation_summary/ErrorSummary.vue
+++ b/src/components/shared/validation_summary/ErrorSummary.vue
@@ -53,7 +53,7 @@ const onClickError = ( focusElementId: string, scrollElementId: string ) => {
 	const focusOptions = { preventScroll: false };
 
 	if ( scrollElement ) {
-		scrollElement.scrollIntoView( { behavior: 'smooth' } );
+		scrollElement.scrollIntoView( { behavior: 'auto' } );
 		focusOptions.preventScroll = true;
 	}
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -9,6 +9,14 @@
 
 @import "bulma";
 
+html {
+	scroll-behavior: smooth;
+
+	@media ( prefers-reduced-motion ) {
+		scroll-behavior: auto;
+	}
+}
+
 .is-form-input-width {
 	width: $fun-min-width !important;
 	@include from($tablet) {

--- a/tests/unit/components/pages/donation_form/DonationForm.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationForm.spec.ts
@@ -493,6 +493,6 @@ describe( 'DonationForm.vue', () => {
 
 		await wrapper.find( '#previous-btn' ).trigger( 'click' );
 
-		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth' } );
+		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'auto' } );
 	} );
 } );

--- a/tests/unit/components/pages/donation_form/DonationFormAnonymousChoice.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationFormAnonymousChoice.spec.ts
@@ -457,6 +457,6 @@ describe( 'DonationFormAnonymousChoice.vue', () => {
 
 		await wrapper.find( '#previous-btn' ).trigger( 'click' );
 
-		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth' } );
+		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'auto' } );
 	} );
 } );

--- a/tests/unit/components/shared/validation_summary/ErrorSummary.spec.ts
+++ b/tests/unit/components/shared/validation_summary/ErrorSummary.spec.ts
@@ -66,7 +66,7 @@ describe( 'ErrorSummary.vue', () => {
 		await wrapper.find( '[href="#amount-500"]' ).trigger( 'click' );
 
 		expect( focusElement.focus ).toHaveBeenCalledWith( { preventScroll: true } );
-		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth' } );
+		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'auto' } );
 	} );
 
 	it( 'Focuses the the invalid field only when a summary item is clicked and no scroll item exists', async () => {


### PR DESCRIPTION
We need to make sure our animations obey the reduced
motion preference:

https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html

This adds the media query to the modal dialogue and
the locale dropdown.

Also passes the `auto` behaviour to scrollIntoView calls to
allow it to support prefers-reduced-motion.

Ticket: https://phabricator.wikimedia.org/T391429

Note: To test this you can toggle reduced motion on your machine by following the instructions here: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences