### PR TITLE
Move Error summaries above the forms

### DIFF
--- a/src/components/pages/Contact.vue
+++ b/src/components/pages/Contact.vue
@@ -10,6 +10,8 @@
 			:focus-on-submit="false"
 		/>
 
+		<ErrorSummary :is-visible="showErrorSummary" :items="validationItems"/>
+
 		<form method="post" action="/contact/get-in-touch" @submit.prevent="submit" id="laika-contact" ref="form">
 			<FormSection>
 				<TextField
@@ -100,8 +102,6 @@
 					@field-changed="() => validateField( 'comment' )"
 				/>
 
-				<ErrorSummary :is-visible="showErrorSummary" :items="validationItems"/>
-
 				<div class="contact-form-button">
 					<FormButton id="submit-btn" button-type="submit">
 						{{ $t('contact_form_submit_button') }}
@@ -113,7 +113,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue';
+import { computed, nextTick, reactive, ref, watch } from 'vue';
 import { Helper } from '@src/store/util';
 import { Validity } from '@src/view_models/Validity';
 import { ContactFormValidation } from '@src/view_models/Validation';
@@ -238,8 +238,10 @@ const validateField = ( fieldName: string ): boolean => {
 	return field.validity === Validity.VALID;
 };
 
-const submit = (): void => {
+const submit = async (): Promise<void> => {
 	let isValid = true;
+	showErrorSummary.value = false;
+
 	Object.keys( formData ).forEach( ( fieldName: string ) => {
 		if ( !validateField( fieldName ) ) {
 			isValid = false;
@@ -249,6 +251,7 @@ const submit = (): void => {
 		trackFormSubmission( form.value );
 		form.value.submit();
 	} else {
+		await nextTick();
 		showErrorSummary.value = true;
 	}
 };

--- a/src/components/pages/UpdateAddress.vue
+++ b/src/components/pages/UpdateAddress.vue
@@ -3,6 +3,60 @@
 		<h1>{{ $t( 'address_change_form_title' ) }}</h1>
 		<p>{{ $t( 'address_change_form_label' ) }}</p>
 
+		<ErrorSummary
+			:is-visible="showErrorSummary"
+			:items="[
+				{
+					validity: store.state.address.validity.companyName,
+					message: $t( 'donation_form_companyname_error' ),
+					focusElement: 'company-name',
+					scrollElement: 'company-name-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.salutation,
+					message: $t( 'donation_form_salutation_error' ),
+					focusElement: 'salutation-0',
+					scrollElement: 'salutation-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.firstName,
+					message: $t( 'donation_form_firstname_error' ),
+					focusElement: 'first-name',
+					scrollElement: 'first-name-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.lastName,
+					message: $t( 'donation_form_lastname_error' ),
+					focusElement: 'last-name',
+					scrollElement: 'last-name-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.street,
+					message: $t( 'donation_form_street_error' ),
+					focusElement: 'street',
+					scrollElement: 'street-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.postcode,
+					message: $t( 'donation_form_zip_error' ),
+					focusElement: 'post-code',
+					scrollElement: 'post-code-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.city,
+					message: $t( 'donation_form_city_error' ),
+					focusElement: 'city',
+					scrollElement: 'city-scroll-target'
+				},
+				{
+					validity: store.state.address.validity.country,
+					message: $t( 'donation_form_country_error' ),
+					focusElement: 'country',
+					scrollElement: 'country-scroll-target'
+				},
+			]"
+		/>
+
 		<form name="laika-address-update" ref="form" @submit.prevent="submit">
 			<CheckboxField
 				v-model="receiptNeeded"
@@ -28,60 +82,6 @@
 				:post-code-validation="addressValidationPatterns.postcode"
 				:country-was-restored="false"
 				v-on:field-changed="onFieldChange"
-			/>
-
-			<ErrorSummary
-				:is-visible="showErrorSummary"
-				:items="[
-					{
-						validity: store.state.address.validity.companyName,
-						message: $t( 'donation_form_companyname_error' ),
-						focusElement: 'company-name',
-						scrollElement: 'company-name-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.salutation,
-						message: $t( 'donation_form_salutation_error' ),
-						focusElement: 'salutation-0',
-						scrollElement: 'salutation-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.firstName,
-						message: $t( 'donation_form_firstname_error' ),
-						focusElement: 'first-name',
-						scrollElement: 'first-name-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.lastName,
-						message: $t( 'donation_form_lastname_error' ),
-						focusElement: 'last-name',
-						scrollElement: 'last-name-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.street,
-						message: $t( 'donation_form_street_error' ),
-						focusElement: 'street',
-						scrollElement: 'street-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.postcode,
-						message: $t( 'donation_form_zip_error' ),
-						focusElement: 'post-code',
-						scrollElement: 'post-code-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.city,
-						message: $t( 'donation_form_city_error' ),
-						focusElement: 'city',
-						scrollElement: 'city-scroll-target'
-					},
-					{
-						validity: store.state.address.validity.country,
-						message: $t( 'donation_form_country_error' ),
-						focusElement: 'country',
-						scrollElement: 'country-scroll-target'
-					},
-				]"
 			/>
 
 			<ServerMessage :server-message="serverErrorMessage"/>
@@ -234,6 +234,7 @@ const getAddressData = (): Address => {
 };
 
 const submit = (): void => {
+	showErrorSummary.value = false;
 	serverErrorMessage.value = '';
 
 	if ( userOnlyWantsToDeclineReceipt.value ) {

--- a/src/components/pages/donation_confirmation/AddressUpdateForm.vue
+++ b/src/components/pages/donation_confirmation/AddressUpdateForm.vue
@@ -1,5 +1,7 @@
 <template>
 	<form id="address-update-form" name="address-update-form" v-on:submit.prevent="submit" method="post" ref="addressForm">
+		<AddressUpdateFormErrorSummaries :address-type="addressType" :show-error-summary="showErrorSummary"/>
+
 		<AutofillHandler v-on:autofill="onAutofill">
 
 			<RadioField
@@ -65,8 +67,6 @@
 		</AutofillHandler>
 
 		<MailingListField v-model="mailingList" input-id="newsletter"/>
-
-		<AddressUpdateFormErrorSummaries :address-type="addressType" :show-error-summary="showErrorSummary"/>
 
 		<FormSummary :show-border="false">
 			<template #summary-buttons>
@@ -268,6 +268,7 @@ const getAddressData = (): UpdateDonorRequest => {
 const submit = async (): Promise<void> => {
 	isValidating.value = true;
 	serverErrorMessage.value = '';
+	showErrorSummary.value = false;
 
 	const validationResult = await validateForm();
 

--- a/src/components/pages/donation_form/DonationReceipt/useDonationFormSubmitHandler.ts
+++ b/src/components/pages/donation_form/DonationReceipt/useDonationFormSubmitHandler.ts
@@ -24,6 +24,10 @@ export function useDonationFormSubmitHandler(
 	const paymentDataIsValid = ref<boolean>( true );
 	const showErrorSummary = computed<boolean>( () => !bankDataIsValid.value || !addressDataIsValid.value || !paymentDataIsValid.value );
 	const submit = async () => {
+		bankDataIsValid.value = true;
+		addressDataIsValid.value = true;
+		paymentDataIsValid.value = true;
+
 		const validationCalls: Promise<any>[] = [
 			store.dispatch( action( 'payment', 'markEmptyValuesAsInvalid' ) ),
 			store.dispatch( action( 'address', 'validateAddressType' ), {

--- a/src/components/pages/donation_form/FormSections/PaymentSection.vue
+++ b/src/components/pages/donation_form/FormSections/PaymentSection.vue
@@ -7,6 +7,8 @@
 		<h1 id="donation-form-heading" class="form-title">{{ $t( 'donation_form_heading' ) }}</h1>
 		<h2 id="donation-form-subheading" class="form-subtitle">{{ $t( 'donation_form_payment_subheading' ) }}</h2>
 
+		<slot name="error-summary"/>
+
 		<PaymentSummary
 			v-if="state === 'showSummary'"
 			@show-payment-form="state='showEntireForm'"

--- a/src/components/pages/donation_form/SubPages/DonationForm.vue
+++ b/src/components/pages/donation_form/SubPages/DonationForm.vue
@@ -4,7 +4,11 @@
 			:payment-amounts="paymentAmounts"
 			:payment-intervals="paymentIntervals"
 			:payment-types="paymentTypes"
-		/>
+		>
+			<template #error-summary>
+				<ErrorSummary :show-error-summary="showErrorSummary" :address-type="addressType"/>
+			</template>
+		</PaymentSection>
 		<div class="donation-page-form-section" v-if="isDirectDebitPayment">
 			<IbanFields/>
 		</div>
@@ -22,8 +26,6 @@
 		/>
 
 		<div class="donation-page-form-section">
-			<ErrorSummary :show-error-summary="showErrorSummary" :address-type="addressType"/>
-
 			<FormSummary>
 				<template #summary-content>
 					<DonationSummary

--- a/src/components/pages/donation_form/SubPages/DonationFormAnonymousChoice.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormAnonymousChoice.vue
@@ -4,7 +4,12 @@
 			:payment-amounts="paymentAmounts"
 			:payment-intervals="paymentIntervals"
 			:payment-types="paymentTypes"
-		/>
+		>
+			<template #error-summary>
+				<OptOutErrorSummary :show-error-summary="showErrorSummary" v-if="addressOptOut.addressOptIn.value === null" />
+				<ErrorSummary :show-error-summary="showErrorSummary" :address-type="addressType" v-else/>
+			</template>
+		</PaymentSection>
 		<div class="donation-page-form-section" v-if="isDirectDebitPayment">
 			<IbanFields/>
 		</div>
@@ -23,9 +28,6 @@
 		/>
 
 		<div class="donation-page-form-section">
-			<OptOutErrorSummary :show-error-summary="showErrorSummary" v-if="addressOptOut.addressOptIn.value === null" />
-			<ErrorSummary :show-error-summary="showErrorSummary" :address-type="addressType" v-else/>
-
 			<FormSummary>
 				<template #summary-content>
 					<DonationSummary

--- a/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
@@ -4,7 +4,11 @@
 			:payment-amounts="paymentAmounts"
 			:payment-intervals="paymentIntervals"
 			:payment-types="paymentTypes"
-		/>
+		>
+			<template #error-summary>
+				<ErrorSummary :show-error-summary="showErrorSummary" :address-type="addressType" :receipt-model="receiptModel"/>
+			</template>
+		</PaymentSection>
 		<div class="donation-page-form-section" v-if="isDirectDebitPayment">
 			<IbanFields/>
 		</div>
@@ -23,12 +27,6 @@
 		/>
 
 		<div class="donation-page-form-section">
-			<ErrorSummary
-				:show-error-summary="showErrorSummary"
-				:address-type="addressType"
-				:receipt-model="receiptModel"
-			/>
-
 			<FormSummary>
 				<template #summary-content>
 					<DonationSummary

--- a/src/components/pages/donation_form/useDonationFormSubmitHandler.ts
+++ b/src/components/pages/donation_form/useDonationFormSubmitHandler.ts
@@ -41,6 +41,10 @@ export function useDonationFormSubmitHandler(
 	const addressDataIsValid = ref<boolean>( true );
 	const showErrorSummary = computed<boolean>( () => !bankDataIsValid.value || !addressDataIsValid.value || !paymentDataIsValid.value );
 	const submit = async (): Promise<void> => {
+		paymentDataIsValid.value = true;
+		bankDataIsValid.value = true;
+		addressDataIsValid.value = true;
+
 		const validationCalls: Promise<any>[] = [
 			store.dispatch( action( 'payment', 'markEmptyValuesAsInvalid' ) ),
 			store.dispatch( action( 'address', 'validateAddressType' ), {

--- a/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -9,16 +9,6 @@
 		<h1 id="membership-form-heading" class="form-title">{{ $t( 'membership_form_headline' ) }}</h1>
 		<h2 id="membership-form-subheading" class="form-subtitle">{{ $t( 'membership_form_address_subheading' ) }}</h2>
 
-		<AddressFields
-			:validate-address-url="validateAddressUrl.toString()"
-			:validate-email-url="validateEmailUrl.toString()"
-			:countries="countries"
-			:salutations="salutations"
-			:address-validation-patterns="addressValidationPatterns"
-			:date-of-birth-validation-pattern="dateOfBirthValidationPattern"
-			ref="addressFieldsRef">
-		</AddressFields>
-
 		<ErrorSummary
 			:is-visible="showErrorSummary"
 			:items="[
@@ -72,6 +62,16 @@
 				},
 			]"
 		/>
+
+		<AddressFields
+			:validate-address-url="validateAddressUrl.toString()"
+			:validate-email-url="validateEmailUrl.toString()"
+			:countries="countries"
+			:salutations="salutations"
+			:address-validation-patterns="addressValidationPatterns"
+			:date-of-birth-validation-pattern="dateOfBirthValidationPattern"
+			ref="addressFieldsRef">
+		</AddressFields>
 
 		<FormSummary>
 			<template #summary-content>
@@ -160,6 +160,7 @@ const membershipApplication = computed( (): MembershipApplication => {
 		paymentType: payment.type,
 		membershipType: membershipTypeName( store.getters[ 'membership_address/membershipType' ] ),
 		incentives: [],
+		isExported: false,
 	};
 } );
 

--- a/src/components/pages/membership_form/subpages/PaymentPage.vue
+++ b/src/components/pages/membership_form/subpages/PaymentPage.vue
@@ -10,6 +10,30 @@
 		<h1 id="membership-form-heading" class="form-title">{{ $t( 'membership_form_headline' ) }}</h1>
 		<h2 id="membership-form-subheading" class="form-subtitle">{{ $t( 'membership_form_payment_subheading' ) }}</h2>
 
+		<ErrorSummary
+			:is-visible="showErrorSummary"
+			:items="[
+				{
+					validity: store.state.membership_fee.validity.interval,
+					message: $t( 'error_summary_interval' ),
+					focusElement: 'interval-0',
+					scrollElement: 'payment-form-interval-scroll-target'
+				},
+				{
+					validity: store.state.membership_fee.validity.fee,
+					message: $t( 'error_summary_amount' ),
+					focusElement: 'amount-500',
+					scrollElement: 'payment-form-amount-scroll-target'
+				},
+				{
+					validity: store.state.bankdata.validity.iban,
+					message: $t( 'donation_form_payment_iban_error' ),
+					focusElement: 'iban',
+					scrollElement: 'iban-scroll-target'
+				},
+			]"
+		/>
+
 		<form>
 			<FormSection v-if="showMembershipTypeOption" title-margin="x-small">
 				<MembershipTypeField
@@ -36,30 +60,6 @@
 			:validate-fee-url="props.validateFeeUrl.toString()"
 			:validate-bank-data-url="props.validateBankDataUrl.toString()"
 			:validate-legacy-bank-data-url="props.validateLegacyBankDataUrl.toString()"
-		/>
-
-		<ErrorSummary
-			:is-visible="showErrorSummary"
-			:items="[
-				{
-					validity: store.state.membership_fee.validity.interval,
-					message: $t( 'error_summary_interval' ),
-					focusElement: 'interval-0',
-					scrollElement: 'payment-form-interval-scroll-target'
-				},
-				{
-					validity: store.state.membership_fee.validity.fee,
-					message: $t( 'error_summary_amount' ),
-					focusElement: 'amount-500',
-					scrollElement: 'payment-form-amount-scroll-target'
-				},
-				{
-					validity: store.state.bankdata.validity.iban,
-					message: $t( 'donation_form_payment_iban_error' ),
-					focusElement: 'iban',
-					scrollElement: 'iban-scroll-target'
-				},
-			]"
 		/>
 
 		<FormSection title="" title-margin="small">
@@ -131,6 +131,10 @@ const isDirectDebitPayment = computed( (): boolean => store.state.membership_fee
 
 const next = async (): Promise<any> => {
 	waitForServerValidationToFinish( store ).then( () => {
+		membershipDataIsValid.value = true;
+		paymentDataIsValid.value = true;
+		bankDataIsValid.value = true;
+
 		const validationActions = [ store.dispatch( action( 'membership_fee', 'markEmptyValuesAsInvalid' ) ) ];
 
 		if ( isDirectDebitPayment.value ) {

--- a/src/components/pages/membership_form/useAddressFormEventHandlers.ts
+++ b/src/components/pages/membership_form/useAddressFormEventHandlers.ts
@@ -25,6 +25,10 @@ export function useAddressFormEventHandlers(
 	const dateOfBirthIsValid = ref<boolean>( true );
 	const showErrorSummary = computed<boolean>( () => !bankDataIsValid.value || !addressDataIsValid.value || !dateOfBirthIsValid.value );
 	const submit = async (): Promise<void> => {
+		bankDataIsValid.value = true;
+		addressDataIsValid.value = true;
+		dateOfBirthIsValid.value = true;
+
 		const validationCalls: Promise<any>[] = [
 			store.dispatch( action( 'membership_address', 'validateAddress' ), validateAddressUrl ),
 			store.dispatch( action( 'membership_address', 'validateEmail' ), validateEmailUrl ),

--- a/src/components/shared/validation_summary/ErrorSummary.vue
+++ b/src/components/shared/validation_summary/ErrorSummary.vue
@@ -10,6 +10,7 @@
 		:aria-labelledby="`${idNamespace}error-summary-heading`"
 		tabindex="-1"
 	>
+		<ScrollTarget :target-id="`${idNamespace}error-summary-scroll-target`"/>
 		<h2 class="error-summary-heading" :id="`${idNamespace}error-summary-heading`">{{ $t( 'error_summary_headline' ) }}</h2>
 		<ul class="error-summary-list">
 			<template v-for="item in items">
@@ -33,6 +34,7 @@
 import { ValidationSummaryItem } from '@src/components/shared/validation_summary/ValidationSummaryItem';
 import { Validity } from '@src/view_models/Validity';
 import { nextTick, ref, watch } from 'vue';
+import ScrollTarget from '@src/components/shared/ScrollTarget.vue';
 
 interface Props {
 	isVisible: boolean;
@@ -63,7 +65,9 @@ const onClickError = ( focusElementId: string, scrollElementId: string ) => {
 watch( () => props.isVisible, async ( newIsVisible: boolean ) => {
 	if ( props.focusOnSubmit && newIsVisible ) {
 		await nextTick();
-		errorSummary.value.focus();
+		const errorScrollElement = document.getElementById( `${props.idNamespace}error-summary-scroll-target` );
+		errorSummary.value.focus( { preventScroll: true } );
+		errorScrollElement.scrollIntoView( { behavior: 'auto' } );
 	}
 } );
 

--- a/tests/unit/components/DonationCommentPopUp.spec.ts
+++ b/tests/unit/components/DonationCommentPopUp.spec.ts
@@ -3,6 +3,10 @@ import DonationCommentPopUp from '@src/components/pages/donation_confirmation/Do
 import { AddressTypeModel, addressTypeName } from '@src/view_models/AddressTypeModel';
 import { failureMessage, FakeFailingCommentResource, FakeSucceedingCommentResource, successMessage } from '@test/unit/TestDoubles/FakeCommentResource';
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'DonationCommentPopUp.vue', () => {
 	function getDefaultConfirmationData( isAnonymous: boolean ): any {
 		const sampleDonationData = {

--- a/tests/unit/components/pages/Contact.spec.ts
+++ b/tests/unit/components/pages/Contact.spec.ts
@@ -3,6 +3,10 @@ import Contact from '@src/components/pages/Contact.vue';
 import { ContactInitialFormData } from '@src/components/pages/contact/ContactInitialFormData';
 import { contactFormValidationPatterns } from '@test/data/validation';
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'Contact.vue', () => {
 
 	const getWrapper = ( initialFormData: ContactInitialFormData = null, errors: Record<string, string> = null ): VueWrapper<any> => {

--- a/tests/unit/components/pages/UpdateAddress.spec.ts
+++ b/tests/unit/components/pages/UpdateAddress.spec.ts
@@ -27,6 +27,10 @@ const defaultAddressChangeResource: AddressChangeResource = {
 	},
 };
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'UpdateAddress.vue', () => {
 
 	const getWrapper = ( store: Store<any> = createStore(), addressChangeResource: AddressChangeResource = defaultAddressChangeResource ): VueWrapper<any> => {

--- a/tests/unit/components/pages/donation_confirmation/AddressUpdateForm.spec.ts
+++ b/tests/unit/components/pages/donation_confirmation/AddressUpdateForm.spec.ts
@@ -95,6 +95,10 @@ const defaultDonorResource: DonorResource = {
 	},
 };
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'AddressUpdateForm.vue', () => {
 	const getWrapper = ( store: Store<any>, confirmationData: any, donorResource: DonorResource = defaultDonorResource ): VueWrapper<any> => {
 		return mount( AddressUpdateForm, {

--- a/tests/unit/components/pages/donation_form/DonationForm.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationForm.spec.ts
@@ -29,8 +29,11 @@ const errorSummaryItemIsFunctional = ( wrapper: VueWrapper<any>, formElement: st
 	return errorItemExists && formElementExists && scrollElementExists;
 };
 
-describe( 'DonationForm.vue', () => {
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
 
+describe( 'DonationForm.vue', () => {
 	beforeEach( () => {
 		global.window.scrollTo = jest.fn();
 		jest.useFakeTimers();

--- a/tests/unit/components/pages/donation_form/DonationFormAnonymousChoice.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationFormAnonymousChoice.spec.ts
@@ -27,6 +27,10 @@ const errorSummaryItemIsFunctional = ( wrapper: VueWrapper<any>, formElement: st
 	return errorItemExists && formElementExists && scrollElementExists;
 };
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'DonationFormAnonymousChoice.vue', () => {
 
 	beforeEach( () => {

--- a/tests/unit/components/pages/donation_form/DonationFormReceipt.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationFormReceipt.spec.ts
@@ -29,6 +29,10 @@ const errorSummaryItemIsFunctional = ( wrapper: VueWrapper<any>, formElement: st
 	return errorItemExists && formElementExists && scrollElementExists;
 };
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'DonationFormReciept.vue', () => {
 
 	beforeEach( () => {

--- a/tests/unit/components/pages/membership_form/AddressPage.spec.ts
+++ b/tests/unit/components/pages/membership_form/AddressPage.spec.ts
@@ -37,6 +37,10 @@ const salutations: Salutation[] = [
 jest.mock( 'axios' );
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'AddressPage.vue', () => {
 	const getWrapper = ( store: Store<any> = createStore() ): { wrapper: VueWrapper<any>; store: Store<any> } => {
 		const wrapper = mount( AddressPage, {

--- a/tests/unit/components/pages/membership_form/PaymentPage.spec.ts
+++ b/tests/unit/components/pages/membership_form/PaymentPage.spec.ts
@@ -10,6 +10,10 @@ import { nextTick } from 'vue';
 import { IBAN } from '@test/data/bankdata';
 import { newSucceedingBankValidationResource } from '@test/unit/TestDoubles/SucceedingBankValidationResource';
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'PaymentPage.vue', () => {
 	let wrapper: VueWrapper<any>;
 	let store: Store<any>;

--- a/tests/unit/components/shared/IbanFields.spec.ts
+++ b/tests/unit/components/shared/IbanFields.spec.ts
@@ -9,6 +9,10 @@ import { newSucceedingBankValidationResource } from '@test/unit/TestDoubles/Succ
 import { accountNumber, bankCode, bankName, BIC, formattedIBAN, IBAN } from '@test/data/bankdata';
 import { newFailingBankValidationResource } from '@test/unit/TestDoubles/FailingBankValidationResource';
 
+// This is so the error summary scrollIntoView doesn't throw errors
+const errorSummaryScrollElement = { scrollIntoView: () => {} };
+Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => errorSummaryScrollElement } );
+
 describe( 'IbanFields.vue', () => {
 	const getWrapper = ( bankValidationResource: BankValidationResource = null, store: Store<any> = null ): VueWrapper<any> => {
 		return mount( IbanFields, {

--- a/tests/unit/components/shared/validation_summary/ErrorSummary.spec.ts
+++ b/tests/unit/components/shared/validation_summary/ErrorSummary.spec.ts
@@ -34,12 +34,16 @@ describe( 'ErrorSummary.vue', () => {
 	};
 
 	it( 'Focuses the summary when it becomes visible', async () => {
+		const scrollElement = { scrollIntoView: jest.fn() };
+		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => scrollElement } );
+
 		const wrapper = getWrapper();
 
 		await wrapper.setProps( { isVisible: true } );
 		await nextTick();
 
 		expect( document.activeElement ).toStrictEqual( wrapper.element );
+		expect( scrollElement.scrollIntoView ).toHaveBeenCalledWith( { behavior: 'auto' } );
 	} );
 
 	it( 'Does not focus the summary when it becomes visible and focusOnSubmit is false', async () => {
@@ -55,9 +59,15 @@ describe( 'ErrorSummary.vue', () => {
 	it( 'Focuses and scrolls the invalid field when a summary item is clicked', async () => {
 		const focusElement = { focus: jest.fn() };
 		const scrollElement = { scrollIntoView: jest.fn() };
-		let calls: number = 0;
-		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => {
-			return calls++ === 0 ? focusElement : scrollElement;
+		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: ( id: string ) => {
+			switch ( id ) {
+				case 'amount-500':
+					return focusElement;
+				case 'payment-form-amount':
+					return scrollElement;
+				default:
+					return { scrollIntoView: () => {} };
+			}
 		} } );
 		const wrapper = getWrapper();
 
@@ -71,9 +81,15 @@ describe( 'ErrorSummary.vue', () => {
 
 	it( 'Focuses the the invalid field only when a summary item is clicked and no scroll item exists', async () => {
 		const element = { focus: jest.fn(), scrollIntoView: jest.fn() };
-		let calls: number = 0;
-		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: () => {
-			return calls++ === 0 ? element : null;
+		Object.defineProperty( document, 'getElementById', { writable: true, configurable: true, value: ( id: string ) => {
+			switch ( id ) {
+				case 'amount-500':
+					return element;
+				case 'payment-form-amount':
+					return null;
+				default:
+					return { scrollIntoView: () => {} };
+			}
 		} } );
 		const wrapper = getWrapper();
 


### PR DESCRIPTION
We should show the error summaries above the forms in
order to satisfy this WCAG AA criteria:
https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html

- Move the error summary on the 3 donation forms
- Move the error summary on the update address form
- Move the error summary on the contact form
- Move the error summary on the update address form
- Move the error summary on the donation comment form
- Make the focus scrolling respect reduced motion
- Make all summaries refocus if submit is hit when it
  is already visible

Ticket: https://phabricator.wikimedia.org/T391660