### PR TITLE
Fix donation number validation

### DIFF
--- a/src/components/pages/Contact.vue
+++ b/src/components/pages/Contact.vue
@@ -167,7 +167,7 @@ const formData = reactive<ContactFormData>( {
 		value: props.initialFormData?.donationNumber ?? '',
 		pattern: props.validationPatterns.donationNumber,
 		optionalField: true,
-		validity: Validity.VALID,
+		validity: props.errors?.donationNumber ? Validity.INVALID : Validity.VALID,
 	},
 	email: {
 		name: 'email',
@@ -201,7 +201,7 @@ const formData = reactive<ContactFormData>( {
 
 const validationItems = computed<ValidationSummaryItem[]>( () => [
 	{
-		validity: formData.email.validity,
+		validity: formData.donationNumber.validity,
 		message: t( 'contact_form_donation_number_error' ),
 		focusElement: 'donationNumber',
 		scrollElement: 'donationNumber-scroll-target',

--- a/tests/unit/components/pages/Contact.spec.ts
+++ b/tests/unit/components/pages/Contact.spec.ts
@@ -42,19 +42,24 @@ describe( 'Contact.vue', () => {
 	it( 'Shows and hides field errors', async () => {
 		const wrapper = getWrapper();
 
-		await wrapper.find( '#laika-contact' ).trigger( 'submit' );
-
+		const donationNumber = wrapper.find( '#donationNumber' );
 		const email = wrapper.find( '#email' );
 		const topic = wrapper.find( '#topic' );
 		const subject = wrapper.find( '#subject' );
 		const messageBody = wrapper.find( '#messageBody' );
 
+		await donationNumber.setValue( 'This field is supposed to only contain numbers' );
+		await wrapper.find( '#laika-contact' ).trigger( 'submit' );
+
+		expect( donationNumber.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( email.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( topic.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( subject.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( messageBody.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( wrapper.find( '.error-summary' ).exists() ).toBeTruthy();
 
+		await donationNumber.setValue( '424242' );
+		await donationNumber.trigger( 'blur' );
 		await email.setValue( 'joe@dolan.com' );
 		await email.trigger( 'blur' );
 		await topic.setValue( 'category_1' );
@@ -64,6 +69,7 @@ describe( 'Contact.vue', () => {
 		await messageBody.setValue( 'Oh me oh my you make me sigh' );
 		await messageBody.trigger( 'blur' );
 
+		expect( donationNumber.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
 		expect( email.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
 		expect( topic.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
 		expect( subject.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
@@ -73,23 +79,28 @@ describe( 'Contact.vue', () => {
 
 	it( 'Shows and hides field errors when initialised with them', async () => {
 		const wrapper = getWrapper( null, {
+			donationNumber: 'field_numeric',
 			subject: 'field_required',
 			category: 'field_required',
 			messageBody: 'field_required',
 			email: 'email_address_wrong_format',
 		} );
 
+		const donationNumber = wrapper.find( '#donationNumber' );
 		const email = wrapper.find( '#email' );
 		const topic = wrapper.find( '#topic' );
 		const subject = wrapper.find( '#subject' );
 		const messageBody = wrapper.find( '#messageBody' );
 
+		expect( donationNumber.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( email.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( topic.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( subject.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( messageBody.attributes( 'aria-invalid' ) ).toStrictEqual( 'true' );
 		expect( wrapper.find( '#server-error-summary' ).exists() ).toBeTruthy();
 
+		await donationNumber.setValue( '424242' );
+		await donationNumber.trigger( 'blur' );
 		await email.setValue( 'joe@dolan.com' );
 		await email.trigger( 'blur' );
 		await topic.setValue( 'category_1' );
@@ -99,6 +110,7 @@ describe( 'Contact.vue', () => {
 		await messageBody.setValue( 'Oh me oh my you make me sigh' );
 		await messageBody.trigger( 'blur' );
 
+		expect( donationNumber.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
 		expect( email.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
 		expect( topic.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );
 		expect( subject.attributes( 'aria-invalid' ) ).toStrictEqual( 'false' );


### PR DESCRIPTION
The donation number is optional but if passed is
required to be numeric.

Fixed display for an incorrect error in the summary when
email is invalid.

Set donation number validity when a field_numeric error is
sent from the application.

Ticket: https://phabricator.wikimedia.org/T392447