### PR TITLE
Add line to allow having multiple definitions for same scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     # look for major+minor dependency updates on a weekly basis
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
+
+    # this line is needed as a workaround to have two groups of updates for the same
+    # package ecosystem. See https://github.com/dependabot/dependabot-core/issues/1778
+    # for the feature request to have a dependabot group for each semver type
+    target-branch: main
+
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
- dependabot does not support defining different schedules for the same ecosystem scope but this line is a workaround to allow doing it
- we have it in our other repositories as well, it was just forgotten to add here