### PR TITLE
Remove auto focus from IBAN calculator error

### DIFF
--- a/src/components/shared/IbanFields.vue
+++ b/src/components/shared/IbanFields.vue
@@ -52,7 +52,7 @@
 								@field-changed="validateBankCode"
 							/>
 
-							<ErrorSummary :is-visible="showCalculatorErrorSummary" :items="[
+							<ErrorSummary :is-visible="showCalculatorErrorSummary" :focus-on-submit="false" :items="[
 								{
 									validity: accountNumberError ? Validity.INVALID : Validity.VALID,
 									message: $t( 'donation_form_account_number_error' ),


### PR DESCRIPTION
The IBAN calculator was being focused when it became
visible, causing the page to scroll. This passes
focus-on-submit false to it to prevent that happening.

Ticket: https://phabricator.wikimedia.org/T394978