### PR TITLE
Remove boolean types, use undefined instead

### DIFF
--- a/src/components/pages/donation_form/DonationSummary.vue
+++ b/src/components/pages/donation_form/DonationSummary.vue
@@ -9,13 +9,13 @@
 		<div class="switcher">
 			<div>
 				<DonorSummary
-					v-if="hasAddressSummary"
+					v-if="address"
 					:address="address"
 					:countries="countries"
 					:salutations="salutations"
 				/>
 			</div>
-			<div v-if="hasBankDataSummary">
+			<div v-if="bankData">
 				<h3 class="summary-title">{{ $t('donation_form_summary_bank_details') }}</h3>
 				<strong>{{ $t('donation_form_summary_iban') }}</strong> {{ bankData.iban }}<br>
 				<strong>{{ $t('donation_form_summary_bic') }}</strong> {{ bankData.bic }}<br>
@@ -34,13 +34,11 @@ import type { Country } from '@src/view_models/Country';
 import type { Salutation } from '@src/view_models/Salutation';
 
 interface Props {
-	address: Address;
+	address: Address | undefined;
 	payment: { interval: any; amount: number; paymentType: any };
-	bankData: { iban: string; bic: string; bankName: string };
+	bankData: { iban: string; bic: string; bankName: string } | undefined;
 	countries: Array<Country>;
 	salutations: Array<Salutation>;
-	hasAddressSummary: boolean;
-	hasBankDataSummary: boolean;
 }
 
 const { t, n } = useI18n();

--- a/src/components/pages/donation_form/SubPages/DonationForm.vue
+++ b/src/components/pages/donation_form/SubPages/DonationForm.vue
@@ -29,8 +29,6 @@
 			<FormSummary>
 				<template #summary-content v-if="hasInteracted">
 					<DonationSummary
-						:hasBankDataSummary="hasBankDataSummary"
-						:hasAddressSummary="hasAddressSummary"
 						:address="addressSummary"
 						:payment="paymentSummary"
 						:bank-data="bankDataSummary"
@@ -100,7 +98,7 @@ const markInteracted = () => {
 };
 
 const store = useStore();
-const { hasBankDataSummary, bankDataSummary } = useBankDataSummary( store );
+const { bankDataSummary } = useBankDataSummary( store );
 const { isDirectDebitPayment, paymentSummary } = usePaymentFunctions( store );
 
 interface Props {
@@ -120,7 +118,7 @@ interface Props {
 }
 const props = defineProps<Props>();
 
-const { addressSummary, hasAddressSummary } = useAddressSummary( store );
+const { addressSummary } = useAddressSummary( store );
 const {
 	disabledAddressTypes,
 	addressType,
@@ -151,7 +149,7 @@ onMounted( () => {
 	const hasPaymentData =
 		paymentSummary.value.amount > 0 || Boolean( paymentSummary.value.paymentType );
 
-	if ( hasAddressSummary.value || hasPaymentData ) {
+	if ( addressSummary.value || hasPaymentData ) {
 		hasInteracted.value = true;
 	}
 } );

--- a/src/components/pages/donation_form/SubPages/DonationFormAnonymousChoice.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormAnonymousChoice.vue
@@ -36,8 +36,6 @@
 						:bank-data="bankDataSummary"
 						:countries="countries"
 						:salutations="salutations"
-						:hasAddressSummary="hasAddressSummary"
-						:hasBankDataSummary="hasBankDataSummary"
 					/>
 				</template>
 
@@ -116,8 +114,8 @@ const props = defineProps<Props>();
 
 const store = useStore();
 const { isDirectDebitPayment, paymentSummary } = usePaymentFunctions( store );
-const { hasAddressSummary, addressSummary } = useAddressSummary( store );
-const { hasBankDataSummary, bankDataSummary } = useBankDataSummary( store );
+const { addressSummary } = useAddressSummary( store );
+const { bankDataSummary } = useBankDataSummary( store );
 const {
 	disabledAddressTypes,
 	addressType,

--- a/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
@@ -35,8 +35,6 @@
 						:bank-data="bankDataSummary"
 						:countries="countries"
 						:salutations="salutations"
-						:hasAddressSummary="hasAddressSummary"
-						:hasBankDataSummary="hasBankDataSummary"
 					/>
 				</template>
 
@@ -114,8 +112,8 @@ const props = defineProps<Props>();
 
 const store = useStore();
 const { isDirectDebitPayment, paymentSummary } = usePaymentFunctions( store );
-const { hasAddressSummary, addressSummary } = useAddressSummary( store );
-const { hasBankDataSummary, bankDataSummary } = useBankDataSummary( store );
+const { addressSummary } = useAddressSummary( store );
+const { bankDataSummary } = useBankDataSummary( store );
 const {
 	disabledAddressTypes,
 	addressType,

--- a/src/components/pages/donation_form/useAddressSummary.ts
+++ b/src/components/pages/donation_form/useAddressSummary.ts
@@ -1,32 +1,26 @@
 import { Store } from 'vuex';
 import { computed, ComputedRef } from 'vue';
+import type { Address } from '@src/view_models/Address';
 
 type ReturnType = {
-	addressSummary: ComputedRef<any>;
-	hasAddressSummary: ComputedRef<boolean>;
+	addressSummary: ComputedRef<Address | undefined>;
 };
 
 export function useAddressSummary( store: Store<any> ): ReturnType {
-	const addressSummary = computed( () => ( {
-		...store.state.address.values,
-		streetAddress: store.state.address.values.street,
-		postalCode: store.state.address.values.postcode,
-		country: store.state.address.values.country,
-	} ) );
-
-	const hasAddressSummary = computed( () => {
-		const address = addressSummary.value;
-		return Boolean(
-			address.companyName?.trim() ||
-			( address.firstName?.trim() && address.lastName?.trim() ) ||
-			address.streetAddress?.trim() ||
-			( address.postalCode?.trim() && address.city?.trim() ) ||
-			address.email?.trim()
-		);
+	const addressSummary = computed( () => {
+		const hasSomeAddressDataFilledOut = store.state.address.companyName?.trim() ||
+			( store.state.address.firstName?.trim() && store.state.address.lastName?.trim() ) ||
+			store.state.address.street?.trim() ||
+			( store.state.address.postcode?.trim() && store.state.address.city?.trim() ) ||
+			store.state.address.email?.trim();
+		if ( !hasSomeAddressDataFilledOut ) {
+			return {
+				...store.state.address.values,
+			};
+		}
 	} );
 
 	return {
 		addressSummary,
-		hasAddressSummary,
 	};
 }

--- a/src/components/pages/donation_form/useBankDataSummary.ts
+++ b/src/components/pages/donation_form/useBankDataSummary.ts
@@ -3,23 +3,16 @@ import { computed, ComputedRef } from 'vue';
 import { usePaymentFunctions } from '@src/components/pages/donation_form/usePaymentFunctions';
 
 type ReturnType = {
-	hasBankDataSummary: ComputedRef<boolean>;
-	bankDataSummary: ComputedRef<{ iban: string; bankName: string; bic: string }>;
+	bankDataSummary: ComputedRef<{ iban: string; bankName: string; bic: string } | undefined>;
 };
 
 export function useBankDataSummary( store: Store<any> ): ReturnType {
 	const { isDirectDebitPayment } = usePaymentFunctions( store );
 	const bankData = store.state.bankdata.values;
 
-	const hasBankDataSummary: ComputedRef<boolean> = computed( () =>
-		Boolean(
-			isDirectDebitPayment.value &&
-			bankData.iban
-		)
-	);
-
 	const bankDataSummary = computed( () => {
-		if ( hasBankDataSummary.value ) {
+		const shouldShowSummary = bankData.iban.trim() && isDirectDebitPayment.value;
+		if ( shouldShowSummary ) {
 			return {
 				iban: bankData.iban,
 				bankName: bankData.bankName,
@@ -30,6 +23,5 @@ export function useBankDataSummary( store: Store<any> ): ReturnType {
 
 	return {
 		bankDataSummary,
-		hasBankDataSummary,
 	};
 }

--- a/tests/unit/components/pages/donation_form/DonationSummary.spec.ts
+++ b/tests/unit/components/pages/donation_form/DonationSummary.spec.ts
@@ -11,7 +11,7 @@ describe( 'DonationSummary.vue', () => {
 		amount: 14.99,
 	};
 
-	const emptyBankData = { iban: '', bic: '', bankName: '' };
+	const emptyBankData = undefined;
 
 	const validBankData = {
 		iban: 'DE02120300000000202051',
@@ -72,20 +72,7 @@ describe( 'DonationSummary.vue', () => {
 		email: 'vlad@example.com',
 	};
 
-	const emptyAddress: Address = {
-		addressType: '',
-		salutation: '',
-		title: '',
-		firstName: '',
-		lastName: '',
-		fullName: '',
-		companyName: '',
-		street: '',
-		postcode: '',
-		city: '',
-		country: '',
-		email: '',
-	};
+	const emptyAddress = undefined;
 
 	interface Props {
 		address: Address;
@@ -93,8 +80,6 @@ describe( 'DonationSummary.vue', () => {
 		bankData: { iban: string; bic: string; bankName: string };
 		countries: Country[];
 		salutations: Salutation[];
-		hasAddressSummary: boolean;
-		hasBankDataSummary: boolean;
 	}
 
 	const mocks = {
@@ -117,8 +102,6 @@ describe( 'DonationSummary.vue', () => {
 			bankData: emptyBankData,
 			countries,
 			salutations,
-			hasAddressSummary: false,
-			hasBankDataSummary: false,
 		} );
 		const text = wrapper.text();
 
@@ -135,8 +118,6 @@ describe( 'DonationSummary.vue', () => {
 			bankData: emptyBankData,
 			countries,
 			salutations,
-			hasAddressSummary: true,
-			hasBankDataSummary: false,
 		} );
 
 		const text = wrapper.text();
@@ -152,19 +133,17 @@ describe( 'DonationSummary.vue', () => {
 			bankData: validBankData,
 			countries,
 			salutations,
-			hasAddressSummary: true,
-			hasBankDataSummary: true,
 		} );
 
 		const text = wrapper.text();
 		expect( wrapper.findComponent( { name: 'DonorSummary' } ).exists() ).toBe( true );
 		expect( text ).toContain( 'donation_form_summary_bank_details' );
 		expect( text ).toContain( 'donation_form_summary_iban' );
-		expect( text ).toContain( emptyBankData.iban );
+		expect( text ).toContain( validBankData.iban );
 		expect( text ).toContain( 'donation_form_summary_bic' );
-		expect( text ).toContain( emptyBankData.bic );
+		expect( text ).toContain( validBankData.bic );
 		expect( text ).toContain( 'donation_form_summary_bank_name' );
-		expect( text ).toContain( emptyBankData.bankName );
+		expect( text ).toContain( validBankData.bankName );
 	} );
 
 	it( 'does NOT render DonorSummary when hasAddressSummary=false', () => {
@@ -174,8 +153,6 @@ describe( 'DonationSummary.vue', () => {
 			bankData: emptyBankData,
 			countries,
 			salutations,
-			hasAddressSummary: false,
-			hasBankDataSummary: false,
 		} );
 		expect( wrapper.findComponent( { name: 'DonorSummary' } ).exists() ).toBe( false );
 	} );
@@ -187,8 +164,6 @@ describe( 'DonationSummary.vue', () => {
 			bankData: emptyBankData,
 			countries,
 			salutations,
-			hasAddressSummary: true,
-			hasBankDataSummary: false,
 		} );
 		const text = wrapper.text();
 


### PR DESCRIPTION
The two composables `useAddressSummary` and `useBankDataSummary` returned both data and a boolean if data is available. This is weird because you could express states that should be impossible (e.g. `hasAddressSummary: false` with filled data and `hasAddressSummary: true` with empty or undefined data). This commit uses a JavaScript primitive for this: `undefined`. `undefined` is one of the [Falsy values](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) which makes it nice for checks. We're using `undefined` instead of `null` because we want to express the fact "there is absolutely no data here, not even a null value". This distinguishes our type from nullable optional types.

The type change also revealed a small bug in DonationSummary.spec.ts where we accidentally expected empty strings, which could have made the test pass where it should not pass. This commit also fixes that bug.

This commit also removes additional properties form the returned address in `useAddressSummary` that would be ignored and are not used anywhere.