### PR TITLE
Improve padding of content card

### DIFF
--- a/src/pattern_library/css/blocks/content-card.css
+++ b/src/pattern_library/css/blocks/content-card.css
@@ -1,5 +1,5 @@
 .content-card {
-	--card-padding: var(--space-l);
+	--card-padding: var(--space-xs-l);
 
 	padding: var(--card-padding);
 	background: var(--color-white);

--- a/src/pattern_library/css/variables/spacing.css
+++ b/src/pattern_library/css/variables/spacing.css
@@ -30,5 +30,6 @@ The one up pairs give us spacing that uses the next step up as it's larger value
 	/* Custom pairs */
 	--space-s-l: clamp(1rem, 0.8333rem + 0.8333vw, 2.25rem);
 	--space-s-xl: clamp(1rem, 0.6833rem + 1.5833vw, 3.375rem);
+	--space-xs-l: clamp(0.75rem, 0.55rem + 1vw, 2.25rem);
 	--space-0-s: clamp(0rem, -0.15rem + 0.75vw, 1.125rem);
 }


### PR DESCRIPTION
The content card padding is too large on small screens.
This adds a new custom variable that reduces it and
also makes it work better with the padding on the
sidebar card.

Ticket: https://phabricator.wikimedia.org/T397700