### PR TITLE
Fix margin on even 2 column radio

### DIFF
--- a/src/components/shared/form_fields/RadioField.vue
+++ b/src/components/shared/form_fields/RadioField.vue
@@ -143,7 +143,9 @@ const onFieldChange = ( newValue: string | number | boolean | null ): void => {
 				padding: 0 map.get(units.$spacing, 'xx-small') 0;
 				margin-bottom: map.get(units.$spacing, 'small');
 
-				&:last-child {
+				/* We remove the margin from all items on the last row */
+				&:last-child,
+				&:nth-child( odd ):nth-last-of-type( 2 ) {
 					margin-bottom: 0;
 				}
 


### PR DESCRIPTION
We remove the margin bottom of the last radio item
in order to keep the spacing consistent with the
next field group. This caused an issue when there
was an even number of items that caused the last
item to get bigger than it's siblings.

This fix makes sure all items in the final row
of a radio group have the margin bottom removed.

Ticket: https://phabricator.wikimedia.org/T397707