### PR TITLE
Fix vertical spacing for payment options radios

### DIFF
--- a/src/components/shared/form_fields/RadioField.vue
+++ b/src/components/shared/form_fields/RadioField.vue
@@ -143,10 +143,12 @@ const onFieldChange = ( newValue: string | number | boolean | null ): void => {
 				padding: 0 map.get(units.$spacing, 'xx-small') 0;
 				margin-bottom: map.get(units.$spacing, 'small');
 
-				/* We remove the margin from all items on the last row */
-				&:last-child,
-				&:nth-child( odd ):nth-last-of-type( 2 ) {
-					margin-bottom: 0;
+				@include breakpoints.tablet-up {
+					/* We remove the margin from all items on the last row */
+					&:last-child,
+					&:nth-child( odd ):nth-last-of-type( 2 ) {
+						margin-bottom: 0;
+					}
 				}
 
 				input {


### PR DESCRIPTION
- We forgot to acceptance test this feature for mobile sizes - https://github.com/wmde/fundraising-app-frontend/pull/680
- This is the correction to the previously mentioned PR

Ticket: https://phabricator.wikimedia.org/T399706