### PR TITLE
Use Node 22 LTS in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -15,7 +15,7 @@ steps:
           - event: [ push, cron, manual ]
             branch:
               exclude: [ dependabot/* ]
-        image: node:20-alpine
+        image: node:22-alpine
         volumes:
           - /home/deploy/fundraising-app-frontend-builds:/build
           - /tmp/woodpeckerci/cache/npm:/npmcache


### PR DESCRIPTION
Node 22.x is the latest LTS version.
Version 18.x that we used in our GitHub Action workflow is no longer
supported and lead to errors with newer dependencies
Version 20.x that we used in the Woodpecker Ci workflow is in
maintenance.
