### PR TITLE
Add fee upgrade patterns

### DIFF
--- a/src/pattern_library/css/blocks/accordion.css
+++ b/src/pattern_library/css/blocks/accordion.css
@@ -3,7 +3,7 @@
 	--details-gutter: var(--gutter);
 	--summary-border: var(--stroke);
 	--summary-margin: var(--space-2xs);
-	--summary-padding: var(--space-2xs);
+	--summary-padding: var(--space-2xs) 0;
 
 	background: var(--background-color, transparent);
 	padding-inline: var(--padding-inline, 0);
@@ -18,7 +18,7 @@
 	display: flex;
 	justify-content: space-between;
 	color: var(--summary-color, currentColor);
-	padding-block: var(--summary-padding);
+	padding: var(--summary-padding);
 	border-block-end: var(--summary-border);
 }
 
@@ -36,11 +36,12 @@
 	white-space: nowrap;
 }
 
-.accordion details[open] {
-	padding-block-end: var(--gutter);
+.accordion + .accordion details[open] {
+	margin-block-start: var(--gutter);
 }
 
 .accordion details[open] summary {
+	--chevron-stroke: var(--summary-color, var(--color-blue-600));
 	margin-block-end: var(--summary-margin);
 	color: var(--summary-color, var(--color-blue-600));
 }
@@ -53,11 +54,15 @@
 	--padding-inline: var(--gutter);
 	--summary-border: 0;
 	--summary-margin: 0;
-	--summary-padding: var(--space-xs);
+	--summary-padding: var(--space-xs) 0;
 }
 
 .accordion[data-theme="wikimedia"] details + details {
 	--details-gutter: 1px;
+}
+
+.accordion[data-theme="wikimedia"] details[open] {
+	padding-block-end: var(--gutter);
 }
 
 .accordion[data-theme="wikimedia"] details:nth-of-type(1n) {

--- a/src/pattern_library/css/blocks/content-card.css
+++ b/src/pattern_library/css/blocks/content-card.css
@@ -13,3 +13,19 @@
 .content-card[data-sidebar-card] {
 	--card-padding: var(--space-xs);
 }
+
+.content-card[data-collapsable] {
+	--card-padding: 0;
+	--summary-color: var(--color-blue-600);
+}
+
+.content-card[data-collapsable] summary {
+	--summary-margin: 0;
+	--summary-padding: var(--space-xs-l);
+	--summary-border: 0;
+}
+
+.content-card[data-collapsable] details > div {
+	padding-inline: var(--space-xs-l);
+	padding-block-end: var(--space-xs-l);
+}

--- a/src/pattern_library/patterns/accordion/description.md
+++ b/src/pattern_library/patterns/accordion/description.md
@@ -1,1 +1,5 @@
 Accordions are  used for grouping lists of data. They come in 2 themes, the standard one and the Wikimedia coloured one that is used on the Use of Funds page.
+
+## Web Standards
+
+Adding `tabindex="0"` to the summary element makes sure it's focusable in all browsers.

--- a/src/pattern_library/patterns/content-card/Examples.vue
+++ b/src/pattern_library/patterns/content-card/Examples.vue
@@ -22,7 +22,19 @@
 		<div class="content-card flow" data-sidebar-card>Sidebar Card has less padding</div>
 		<div class="content-card flow" data-theme="bordered">Content</div>
 	</div>
+
+	<div class="content-card accordion" data-collapsable>
+		<details>
+			<summary tabindex="0">I am a details summary <span class="accordion__summary-meta"><ChevronDown/></span></summary>
+			<div class="flow">
+				<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam asperiores, autem beatae consectetur corporis distinctio earum eveniet fugit illum impedit molestias
+				   obcaecati officiis optio pariatur rerum sequi similique soluta sunt.</p>
+			</div>
+		</details>
+	</div>
 </template>
 <script setup lang="ts">
+import ChevronDown from '@src/components/shared/icons/ChevronDown.vue';
+
 defineOptions( { inheritAttrs: false } );
 </script>

--- a/src/pattern_library/patterns/content-card/description.md
+++ b/src/pattern_library/patterns/content-card/description.md
@@ -1,1 +1,1 @@
-All content on the site is contained in these cards. They have 3 variants, the standard card, the blue bordered card, and the sidebar card.
+All content on the site is contained in these cards. They have 4 variants, the standard card, the blue bordered card, the sidebar card, and the collapsable card.

--- a/src/pattern_library/patterns/content-card/markup.html
+++ b/src/pattern_library/patterns/content-card/markup.html
@@ -24,3 +24,13 @@
 	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam asperiores, autem beatae consectetur corporis distinctio earum eveniet fugit illum impedit molestias
 	   obcaecati officiis optio pariatur rerum sequi similique soluta sunt.</p>
 </div>
+
+<div class="content-card accordion" data-collapsable>
+	<details>
+		<summary tabindex="0">I am a details summary <span class="accordion__summary-meta"><ChevronDown/></span></summary>
+		<div class="flow">
+			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam asperiores, autem beatae consectetur corporis distinctio earum eveniet fugit illum impedit molestias
+			   obcaecati officiis optio pariatur rerum sequi similique soluta sunt.</p>
+		</div>
+	</details>
+</div>


### PR DESCRIPTION
Add collapsable content card extension to allow a content card to contain a
collapsable accordion element.

Ticket: https://phabricator.wikimedia.org/T396008
