### PR TITLE
Add production implementation of icon text

### DIFF
--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -1,14 +1,24 @@
 <template>
 	<div class="sidebar-cards">
-		<div class="sidebar-card">
-			<h2 class="sidebar-card-title"><InfoIcon/>{{ $t('sidebar_getintouch_headline') }}</h2>
-			<p v-html="appendCampaignQueryParams( $t('sidebar_getintouch_mixed'), campaignParams )"></p>
-			<slot name="default"/>
-		</div>
-		<div class="sidebar-card">
-			<h2 class="sidebar-card-title"><BankIcon/>{{ $t('bank_data_title') }}</h2>
-			<BankData/>
-		</div>
+		<ContentCard :is-sidebar-card="true">
+			<template #content>
+				<IconText :is-small-heading="true">
+					<template #icon><InfoIcon/></template>
+					<template #content><h2>{{ $t('sidebar_getintouch_headline') }}</h2></template>
+				</IconText>
+				<p v-html="appendCampaignQueryParams( $t('sidebar_getintouch_mixed'), campaignParams )"></p>
+				<slot name="default"/>
+			</template>
+		</ContentCard>
+		<ContentCard :is-sidebar-card="true">
+			<template #content>
+				<IconText :is-small-heading="true">
+					<template #icon><BankIcon/></template>
+					<template #content><h2>{{ $t('bank_data_title') }}</h2></template>
+				</IconText>
+				<BankData/>
+			</template>
+		</ContentCard>
 	</div>
 </template>
 
@@ -19,6 +29,8 @@ import BankIcon from '@src/components/shared/icons/BankIcon.vue';
 import InfoIcon from '@src/components/shared/icons/InfoIcon.vue';
 import { appendCampaignQueryParams } from '@src/util/append_campaign_query_params';
 import { QUERY_STRING_INJECTION_KEY } from '@src/util/createCampaignQueryString';
+import ContentCard from '@src/components/patterns/ContentCard.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 const campaignParams = inject<string>( QUERY_STRING_INJECTION_KEY, '' );
 

--- a/src/components/pages/DonationConfirmation.vue
+++ b/src/components/pages/DonationConfirmation.vue
@@ -197,22 +197,6 @@ const showAddress = computed<boolean>( () => {
 	}
 }
 
-.icon-title {
-	padding-left: 2.5rem;
-	svg {
-		float: left;
-		margin-left: -2.5rem;
-	}
-}
-
-h1.icon-title svg {
-	margin-top: 2px;
-}
-
-h2.icon-title {
-	font-size: 1.3rem;
-}
-
 .donation {
 	&-summary {
 		&-wrapper {

--- a/src/components/pages/MembershipConfirmation.vue
+++ b/src/components/pages/MembershipConfirmation.vue
@@ -1,7 +1,11 @@
 <template>
 	<div class="membership-confirmation">
 		<div class="membership-confirmation-summary membership-confirmation-card">
-			<h1 class="icon-title"><SuccessIcon/> {{ $t( 'membership_confirmation_thanks_text' ) }}</h1>
+			<IconText>
+				<template #icon><SuccessIcon/></template>
+				<template #content><h1>{{ $t( 'membership_confirmation_thanks_text' ) }}</h1></template>
+			</IconText>
+
 			<p v-html="$t( 'membership_confirmation_payment_data_text', summaryData )"/>
 
 			<p v-if="hasIncentives">{{ $t( 'membership_confirmation_success_text_incentive' ) }}</p>
@@ -11,7 +15,10 @@
 		</div>
 
 		<div class="membership-confirmation-card" v-if="!confirmationData.membershipApplication.isExported">
-			<h2 class="icon-title"><SuccessIcon/> {{ $t( 'membership_confirmation_address_head' ) }}</h2>
+			<IconText>
+				<template #icon><SuccessIcon/></template>
+				<template #content><h2>{{ $t( 'membership_confirmation_address_head' ) }}</h2></template>
+			</IconText>
 			<p>
 				<template v-if="address.applicantType === 'person'">{{ salutation }}{{ address.fullName }}</template>
 				<template v-else>{{ address.fullName }}</template>
@@ -23,15 +30,16 @@
 			<p>{{ address.email }}</p>
 		</div>
 		<div class="membership-confirmation-card" v-else>
-			<h2 class="icon-title">
-				<WarningIcon/> {{ $t( 'membership_confirmation_exported_title' ) }}
-			</h2>
+			<IconText>
+				<template #icon><WarningIcon/></template>
+				<template #content><h2>{{ $t( 'membership_confirmation_exported_title' ) }}</h2></template>
+			</IconText>
 			<p>
 				{{ $t( 'membership_confirmation_exported_content' ) }}
 			</p>
 		</div>
 
-		<membership-survey
+		<MembershipSurvey
 			v-if="$t( 'membership_confirmation_survey_link') !== ''"
 			:tracking="confirmationData.tracking ?? ''"
 		/>
@@ -52,6 +60,7 @@ import { YearlyMembershipFee } from '@src/view_models/MembershipFee';
 import { useI18n } from 'vue-i18n';
 import SuccessIcon from '@src/components/shared/icons/SuccessIcon.vue';
 import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	confirmationData: MembershipApplicationConfirmationData;
@@ -143,22 +152,6 @@ const summaryData = computed( () => {
 	padding: 32px;
 	line-height: 1.5;
 	margin-bottom: 12px;
-}
-
-.icon-title {
-	padding-left: 2.5rem;
-	svg {
-		float: left;
-		margin-left: -2.5rem;
-	}
-}
-
-h1.icon-title svg {
-	margin-top: 2px;
-}
-
-h2.icon-title {
-	font-size: 1.3rem;
 }
 
 </style>

--- a/src/components/pages/donation_confirmation/AddressAnonymous.vue
+++ b/src/components/pages/donation_confirmation/AddressAnonymous.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="donation-confirmation-card anonymous-address">
-		<h2 class="icon-title"><warning-icon/>{{ $t( 'donation_confirmation_cta_title_alt' ) }}</h2>
+		<IconText>
+			<template #icon><WarningIcon/></template>
+			<template #content><h2>{{ $t( 'donation_confirmation_cta_title_alt' ) }}</h2></template>
+		</IconText>
 		<p>{{ $t( 'donation_confirmation_cta_summary_alt' ) }}</p>
 		<FormButton
 			id="address-change-button"
@@ -19,6 +22,7 @@
 import AddressUsageToggle from '@src/components/pages/donation_confirmation/AddressUsageToggle.vue';
 import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
 import FormButton from '@src/components/shared/form_elements/FormButton.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	modalIsVisible: boolean;

--- a/src/components/pages/donation_confirmation/AddressKnown.vue
+++ b/src/components/pages/donation_confirmation/AddressKnown.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="donation-confirmation-card known-address">
-		<h2 class="icon-title">
-			<SuccessIcon/>
-			{{ $t( donation.receipt ? 'donation_confirmation_summary_title' : 'donation_confirmation_summary_title_no_receipt_wanted' ) }}
-		</h2>
+		<IconText>
+			<template #icon><SuccessIcon/></template>
+			<template #content><h2>{{ $t( donation.receipt ? 'donation_confirmation_summary_title' : 'donation_confirmation_summary_title_no_receipt_wanted' ) }}</h2></template>
+		</IconText>
 
 		<div class="address-summary">
 			<p v-if="addressType === 'person'" v-html="$t( 'donation_confirmation_address_person', {
@@ -46,6 +46,7 @@ import { TranslateResult } from 'vue-i18n';
 import type { Address } from '@src/view_models/Address';
 import type { Salutation } from '@src/view_models/Salutation';
 import ButtonLink from '@src/components/shared/ButtonLink.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	modalIsVisible: boolean;

--- a/src/components/pages/donation_confirmation/DonationExported.vue
+++ b/src/components/pages/donation_confirmation/DonationExported.vue
@@ -1,8 +1,9 @@
 <template>
 	<div class="donation-confirmation-card exported-donation">
-		<h2 class="icon-title">
-			<WarningIcon/> {{ $t( 'donation_confirmation_exported_title' ) }}
-		</h2>
+		<IconText>
+			<template #icon><WarningIcon/></template>
+			<template #content><h2>{{ $t( 'donation_confirmation_exported_title' ) }}</h2></template>
+		</IconText>
 		<p>
 			{{ $t( 'donation_confirmation_exported_content' ) }}
 		</p>
@@ -12,10 +13,11 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 export default defineComponent( {
 	name: 'DonationExported',
-	components: { WarningIcon },
+	components: { IconText, WarningIcon },
 	props: {
 		addressType: String,
 	},

--- a/src/components/pages/donation_confirmation/DonationSurvey.vue
+++ b/src/components/pages/donation_confirmation/DonationSurvey.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="donation-confirmation-card donation-survey">
-		<h2 class="icon-title"><donor-icon/> {{ $t( 'donation_confirmation_survey_title' ) }}</h2>
+		<IconText>
+			<template #icon><DonorIcon/></template>
+			<template #content><h2>{{ $t( 'donation_confirmation_survey_title' ) }}</h2></template>
+		</IconText>
 		<p>{{ $t( 'donation_confirmation_survey_content' ) }}</p>
 		<p><a target="_blank" :href="$t( 'donation_confirmation_survey_link', { tracking: tracking } )">{{ $t( 'donation_confirmation_survey_link_text' ) }} <ExternalLink/></a></p>
 	</div>
@@ -9,6 +12,7 @@
 <script setup lang="ts">
 import DonorIcon from '@src/components/shared/icons/DonorIcon.vue';
 import ExternalLink from '@src/components/shared/icons/ExternalLink.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	tracking: string;

--- a/src/components/pages/donation_confirmation/MembershipInfo.vue
+++ b/src/components/pages/donation_confirmation/MembershipInfo.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="donation-confirmation-card membership-benefits-wrapper">
-		<h2 class="icon-title"><warning-icon/> {{ $t( 'donation_confirmation_membership_call_to_action_title' ) }}</h2>
+		<IconText>
+			<template #icon><WarningIcon/></template>
+			<template #content><h2>{{ $t( 'donation_confirmation_membership_call_to_action_title' ) }}</h2></template>
+		</IconText>
 		<p>{{ $t( 'donation_confirmation_membership_call_to_action_text' ) }}</p>
 		<p>
 			<a ref="buttonRef" class="form-button" id="membership-application-url" :href="membershipApplicationUrl">
@@ -25,6 +28,7 @@
 import { computed, inject, onMounted, onUnmounted, ref } from 'vue';
 import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
 import { QUERY_STRING_INJECTION_KEY } from '@src/util/createCampaignQueryString';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	donation: {

--- a/src/components/pages/donation_confirmation/SuccessMessage.vue
+++ b/src/components/pages/donation_confirmation/SuccessMessage.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="donation-confirmation-card success-message">
-		<h1 class="icon-title"><SuccessIcon/> {{ $t( 'donation_confirmation_topbox_payment_title_alt' ) }}</h1>
+		<IconText>
+			<template #icon><SuccessIcon/></template>
+			<template #content><h1>{{ $t( 'donation_confirmation_topbox_payment_title_alt' ) }}</h1></template>
+		</IconText>
 		<p>
 			<span v-html="donationSummaryMessage"/> <span v-html="paymentNotice"/>
 		</p>
@@ -28,10 +31,12 @@
 import { defineComponent } from 'vue';
 import type { Donation } from '@src/view_models/Donation';
 import SuccessIcon from '@src/components/shared/icons/SuccessIcon.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 export default defineComponent( {
 	name: 'SuccessMessage',
 	components: {
+		IconText,
 		SuccessIcon,
 	},
 	props: {

--- a/src/components/pages/donation_confirmation/SuccessMessageBankTransfer.vue
+++ b/src/components/pages/donation_confirmation/SuccessMessageBankTransfer.vue
@@ -2,7 +2,10 @@
 	<div class="donation-confirmation-card success-message-bank-transfer">
 		<div class="columns is-multiline pt-0 pb-0 mt-0 mb-0">
 			<div class="column is-full pt-0 pb-0 mt-0 mb-0">
-				<h1 class="icon-title"><WarningIcon /> {{ $t( 'donation_confirmation_topbox_payment_title_bank_transfer_alt' ) }}</h1>
+				<IconText>
+					<template #icon><WarningIcon/></template>
+					<template #content><h1>{{ $t( 'donation_confirmation_topbox_payment_title_bank_transfer_alt' ) }}</h1></template>
+				</IconText>
 			</div>
 			<div class="column is-half pt-0 pb-0">
 				<div class="bank-data-content">
@@ -27,6 +30,7 @@ import type { Donation } from '@src/view_models/Donation';
 import BankData from '@src/components/shared/BankData.vue';
 import WarningIcon from '@src/components/shared/icons/WarningIcon.vue';
 import { useI18n } from 'vue-i18n';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	donation: Donation;

--- a/src/components/pages/membership_confirmation/MembershipSurvey.vue
+++ b/src/components/pages/membership_confirmation/MembershipSurvey.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="membership-confirmation-card membership-survey">
-		<h2 class="icon-title"><donor-icon/> {{ $t( 'membership_confirmation_survey_title' ) }}</h2>
+		<IconText>
+			<template #icon><DonorIcon/></template>
+			<template #content><h2>{{ $t( 'membership_confirmation_survey_title' ) }}</h2></template>
+		</IconText>
 		<p>{{ $t( 'membership_confirmation_survey_content' ) }}</p>
 		<p><a target="_blank" :href="$t( 'membership_confirmation_survey_link', { tracking: tracking } )">{{ $t( 'membership_confirmation_survey_link_text' ) }} <ExternalLink/></a></p>
 	</div>
@@ -9,6 +12,7 @@
 <script setup lang="ts">
 import DonorIcon from '@src/components/shared/icons/DonorIcon.vue';
 import ExternalLink from '@src/components/shared/icons/ExternalLink.vue';
+import IconText from '@src/components/patterns/IconText.vue';
 
 interface Props {
 	tracking: string;

--- a/src/components/patterns/ContentCard.vue
+++ b/src/components/patterns/ContentCard.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="content-card flow" :data-sidebar-card="isSidebarCard" :data-theme="theme">
+	<div class="content-card flow" :data-sidebar-card="isSidebarCard ? true : null" :data-theme="theme">
 		<SectionHeading v-if="$slots.heading">
 			<slot name="heading"/>
 		</SectionHeading>

--- a/src/components/patterns/IconText.vue
+++ b/src/components/patterns/IconText.vue
@@ -1,0 +1,12 @@
+<template>
+	<div class="icon-text" :data-small-heading="isSmallHeading ? true : null">
+		<div class="icon-text__icon" aria-hidden="true"><slot name="icon"/></div><slot name="content"/>
+	</div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+	isSmallHeading?: boolean;
+}
+defineProps<Props>();
+</script>

--- a/src/components/shared/IbanFields.vue
+++ b/src/components/shared/IbanFields.vue
@@ -17,9 +17,12 @@
 			<ScrollTarget target-id="iban-calculator-scroll-target"/>
 
 			<div class="iban-calculator-content">
-				<h3 class="icon-title">
-					<BankIcon/> {{ $t( 'donation_form_iban_calculator_title' ) }}
-				</h3>
+				<div class="title">
+					<IconText :is-small-heading="true">
+						<template #icon><BankIcon/></template>
+						<template #content><p>{{ $t('donation_form_iban_calculator_title') }}</p></template>
+					</IconText>
+				</div>
 
 				<button class="iban-calculator-close" @click.prevent="showCalculator = false" aria-controls="iban-calculator">
 					<span class="is-sr-only">{{ $t( 'close' ) }}</span>
@@ -128,6 +131,7 @@ import type { BankValidationResource } from '@src/api/BankValidationResource';
 import { useStore } from 'vuex';
 import type { BankAccountResponse } from '@src/view_models/BankAccount';
 import { action } from '@src/store/util';
+import IconText from '@src/components/patterns/IconText.vue';
 
 const bankValidationResource = inject<BankValidationResource>( 'bankValidationResource' );
 const store = useStore();
@@ -376,16 +380,11 @@ watch( () => store.state.bankdata.values.iban, ( newIban: string ) => {
 		}
 	}
 
-	.icon-title {
-		padding: map.get(units.$spacing, 'small') 0 0 1.5rem;
+	.title {
+		padding: map.get(units.$spacing, 'small') 0 0;
 		margin: 0 map.get(units.$spacing, 'small');
 		font-size: 18px;
 		line-height: 25px;
-
-		svg {
-			float: left;
-			margin: 4px 0 0 -1.5rem;
-		}
 	}
 }
 

--- a/src/pattern_library/css/blocks/icon-text.css
+++ b/src/pattern_library/css/blocks/icon-text.css
@@ -1,21 +1,25 @@
 .icon-text {
+	--icon-height: calc(var(--type-step-0) * var(--leading-standard));
+	--icon-gutter: 1ch;
+
 	display: flex;
 }
 
-.icon-text:not(:has(h1, h2, h3)) {
-	--icon-height: calc(var(--type-step-0) * var(--leading-standard));
-	--icon-gutter: 1ch;
+.icon-text[data-small-heading] :is(h1, h2, h3) {
+	font-size: var(--type-step-0);
+	line-height: var(--leading-standard);
+	font-weight: bold;
 }
 
-.icon-text:has(h1) {
+.icon-text:not([data-small-heading]):has(h1) {
 	--icon-height: calc(var(--type-step-3) * var(--leading-fine));
 }
 
-.icon-text:has(h2) {
+.icon-text:not([data-small-heading]):has(h2) {
 	--icon-height: calc(var(--type-step-2) * var(--leading-fine));
 }
 
-.icon-text:has(h3) {
+.icon-text:not([data-small-heading]):has(h3) {
 	--icon-height: calc(var(--type-step-1) * var(--leading-fine));
 }
 

--- a/src/pattern_library/patterns/icon-text/Examples.vue
+++ b/src/pattern_library/patterns/icon-text/Examples.vue
@@ -24,6 +24,18 @@
 		<div class="icon-text">
 			<div class="icon-text__icon" aria-hidden="true"><BankIcon/></div><p>Long text. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium amet, consectetur culpa doloremque ex, exercitationem harum illum in ipsa ipsum, modi natus nemo odio perferendis quaerat quis similique sint tempore.</p>
 		</div>
+
+		<div class="icon-text" data-small-heading>
+			<div class="icon-text__icon" aria-hidden="true"><InfoIcon/></div><h1>Icon heading 1 small</h1>
+		</div>
+
+		<div class="icon-text" data-small-heading>
+			<div class="icon-text__icon" aria-hidden="true"><InfoIcon/></div><h2>Icon heading 2 small</h2>
+		</div>
+
+		<div class="icon-text" data-small-heading>
+			<div class="icon-text__icon" aria-hidden="true"><BankIcon/></div><h3>Icon heading 3 small</h3>
+		</div>
 	</div>
 </template>
 <script setup lang="ts">

--- a/src/pattern_library/samples/donation-form/Sample.vue
+++ b/src/pattern_library/samples/donation-form/Sample.vue
@@ -358,8 +358,8 @@
 		<aside>
 			<SidebarLinks :content="content">
 				<div class="content-card" data-sidebar-card>
-					<div class="icon-text">
-						<div class="icon-text__icon" aria-hidden="true"><InfoIcon/></div><p><strong>Any questions about making a donation?</strong></p>
+					<div class="icon-text" data-small-heading>
+						<div class="icon-text__icon" aria-hidden="true"><InfoIcon/></div><h2>Any questions about making a donation?</h2>
 					</div>
 					<p>
 						Please contact us using the <a href="#">contact form</a> or by calling: <a href="#">(030) 577 11 62-19</a>
@@ -367,8 +367,8 @@
 				</div>
 
 				<div class="content-card" data-sidebar-card>
-					<div class="icon-text">
-						<div class="icon-text__icon" aria-hidden="true"><BankIcon/></div><p><strong>Donation Account</strong></p>
+					<div class="icon-text" data-small-heading>
+						<div class="icon-text__icon" aria-hidden="true"><BankIcon/></div><h2>Donation Account</h2>
 					</div>
 					<ul class="sidebar-links">
 						<li><strong>Account holder:</strong> Wikimedia e. V.</li>

--- a/src/scss/pattern-library-compatibility/content-card.scss
+++ b/src/scss/pattern-library-compatibility/content-card.scss
@@ -14,3 +14,16 @@
 		padding: map.get( units.$spacing, 'large' );
 	}
 }
+
+.content-card[data-sidebar-card] {
+	--flow-space: 0;
+	padding: 16px;
+	margin-bottom: 16px;
+	line-height: 1.5;
+
+	.bank-data-list {
+		list-style-type: none;
+		padding-left: 0;
+	}
+}
+

--- a/src/scss/pattern-library-compatibility/icon-text.scss
+++ b/src/scss/pattern-library-compatibility/icon-text.scss
@@ -1,0 +1,32 @@
+.icon-text {
+	display: flex;
+	flex-wrap: nowrap;
+}
+
+.icon-text[data-small-heading] :is(h1, h2, h3) {
+	font-size: 16px;
+	font-weight: bold;
+	margin-bottom: 0;
+}
+
+.icon-text__icon {
+	margin-right: 16px;
+}
+
+.icon-text:has(p) .icon-text__icon {
+	margin-right: 8px;
+}
+
+.icon-text[data-small-heading] {
+	.icon-text__icon {
+		margin-right: 5px;
+	}
+}
+
+.icon-text:has(h1) svg {
+	margin-top: 2px;
+}
+
+.icon-text h2 {
+	font-size: 1.3rem;
+}

--- a/src/scss/pattern-library.scss
+++ b/src/scss/pattern-library.scss
@@ -1,9 +1,11 @@
 @use "settings/units";
 @use "sass:map";
-@use "pattern-library-compatibility/content-card";
-@use "pattern-library-compatibility/section-heading";
-@use "pattern-library-compatibility/summary";
-@use "pattern-library-compatibility/switcher";
+
+@import "pattern-library-compatibility/content-card";
+@import "pattern-library-compatibility/icon-text";
+@import "pattern-library-compatibility/section-heading";
+@import "pattern-library-compatibility/summary";
+@import "pattern-library-compatibility/switcher";
 
 @import "../pattern_library/css/variables/global.css";
 @import "../pattern_library/css/compositions/flow.css";


### PR DESCRIPTION
This adds the icon text block/pattern to the production
site and some compatibility code.

It also adds a new extension to the icon text pattern
to allow headings to be styled as normal text. This is
useful for sidebars.

Ticket: https://phabricator.wikimedia.org/T396008