### PR TITLE
Add custom sidebar to root component

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -11,7 +11,7 @@
 					<component :is="page" v-bind="pageProps"/>
 				</template>
 				<template #sidebar v-if="hasSidebar">
-					<AppSidebar/>
+					<component :is="sidebar ?? AppSidebar" v-bind="sidebarProps"/>
 				</template>
 			</AppContent>
 		</div>
@@ -35,8 +35,10 @@ interface Props {
 	pageIdentifier: string;
 	page: Component;
 	pageProps?: Record<string, any>;
-	pageTitle: string;
 	hasSidebar?: boolean;
+	sidebar?: Component;
+	sidebarProps?: Record<string, any>;
+	pageTitle: string;
 	bucketClasses?: string[];
 }
 

--- a/tests/unit/components/App.spec.ts
+++ b/tests/unit/components/App.spec.ts
@@ -1,17 +1,17 @@
-import { shallowMount, VueWrapper } from '@vue/test-utils';
+import { mount, VueWrapper } from '@vue/test-utils';
 import App from '@src/components/App.vue';
 import { ModalStates, useModalState } from '@src/components/shared/composables/useModalState';
-import { nextTick } from 'vue';
+import { markRaw, nextTick } from 'vue';
 
 const modalState = useModalState();
 
 describe( 'App.vue', () => {
 	const getWrapper = (): VueWrapper<any> => {
-		return shallowMount( App, {
+		return mount( App, {
 			props: {
 				assetsPath: 'http://localhost:7072',
 				pageIdentifier: 'test-page',
-				page: { name: 'TestName', template: '<span></span>' },
+				page: markRaw( { name: 'TestName', template: '<span></span>' } ),
 				pageTitle: 'test_page_title',
 				pageProps: {},
 				isFullWidth: false,
@@ -49,5 +49,33 @@ describe( 'App.vue', () => {
 		expect( document.body.style.position ).toStrictEqual( '' );
 		expect( document.body.style.top ).toStrictEqual( '' );
 		expect( scrollTo ).toHaveBeenCalledWith( 0, 0 );
+	} );
+
+	it( 'hides the sidebar when needed', async () => {
+		const wrapper = getWrapper();
+
+		expect( wrapper.find( '.main-content > .sidebar' ).exists() ).toBeTruthy();
+
+		await wrapper.setProps( { hasSidebar: false } );
+
+		expect( wrapper.find( '.main-content > .sidebar' ).exists() ).toBeFalsy();
+	} );
+
+	it( 'shows the default sidebar content', () => {
+		const wrapper = getWrapper();
+
+		expect( wrapper.find( '.main-content > .sidebar' ).html() ).toContain( 'sidebar_getintouch_headline' );
+		expect( wrapper.find( '.main-content > .sidebar' ).html() ).toContain( 'bank_data_title' );
+	} );
+
+	it( 'shows custom sidebar content', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.setProps( {
+			sidebarProps: { memberNumber: '12345678' },
+			sidebar: markRaw( { name: 'TestName', props: [ 'memberNumber' ], template: '<span>CUSTOM SIDEBAR, LALALA! {{ memberNumber }}</span>' } ),
+		} );
+
+		expect( wrapper.find( '.main-content > .sidebar' ).html() ).toContain( 'CUSTOM SIDEBAR, LALALA! 12345678' );
 	} );
 } );


### PR DESCRIPTION
This allows an entry point to specify a custom sidebar. It
works similarly to how we specify pages.

To use a custom sidebar:

1. Pass a sidebar in rootProps when you create the app
   in your entry point. `sidebar: MySidebarComponent`
2. Optionally pass props as an object to your custom
   sidebar in rootProps. `sidebarProps: { myProp: '1234' }`

Ticket: https://phabricator.wikimedia.org/T396008