### PR TITLE
Fix the footer bottom margin

### DIFF
--- a/src/components/layout/AppFooter.vue
+++ b/src/components/layout/AppFooter.vue
@@ -63,8 +63,12 @@ const footerMenu = [
 	}
 
 	&-wrapper {
-		margin-top: auto;
 		background: colors.$footer;
+		margin-top: 16px;
+
+		@include breakpoints.tablet-up {
+			margin-top: 32px;
+		}
 	}
 
 	&-left {

--- a/src/components/pages/donation_form/SubPages/DonationForm.vue
+++ b/src/components/pages/donation_form/SubPages/DonationForm.vue
@@ -68,7 +68,7 @@
 		</template>
 	</ContentCard>
 
-	<form :action="`/donation/add?${campaignParams}`" method="post" ref="submitValuesForm" id="submit-form">
+	<form :action="`/donation/add?${campaignParams}`" method="post" ref="submitValuesForm" id="submit-form" class="visually-hidden" aria-hidden="true">
 		<SubmitValues :tracking-data="trackingData" :campaign-values="campaignValues"/>
 	</form>
 

--- a/src/scss/pattern-library-compatibility/content-card.scss
+++ b/src/scss/pattern-library-compatibility/content-card.scss
@@ -19,18 +19,14 @@
 	}
 }
 
-.content-card:not(:last-child) {
-	margin-bottom: 32px;
+.content-card + .content-card {
+	margin-top: 16px;
 }
 
 .content-card[data-sidebar-card] {
 	--flow-space: 0;
 	padding: 16px;
 	line-height: 1.5;
-}
-
-.content-card[data-sidebar-card]:not(:last-child) {
-	margin-bottom: 16px;
 }
 
 .content-card[data-theme='bordered'] {

--- a/src/scss/pattern-library-compatibility/wrapper.scss
+++ b/src/scss/pattern-library-compatibility/wrapper.scss
@@ -7,6 +7,7 @@ body {
 
 .content-wrapper {
 	--wrapper-padding: 6px;
+	flex-grow: 1;
 
 	@include breakpoints.tablet-up {
 		--wrapper-padding: 18px;

--- a/src/scss/pattern-library.scss
+++ b/src/scss/pattern-library.scss
@@ -2,6 +2,7 @@
 @use "settings/colors";
 @use "sass:map";
 @use "../pattern_library/css/utilities/stretch-single-content-card.css";
+@use "../pattern_library/css/utilities/visually-hidden.css";
 @use "../pattern_library/css/compositions/flow.css";
 @use "../pattern_library/css/compositions/sidebar.css";
 @use "../pattern_library/css/compositions/switcher.css" as switcherBase;


### PR DESCRIPTION
We had a rule that made the last content card
have no margin bottom. This caused the footer
to snuggle up against the content too much.

- Add visually hidden to the submit values form
  in order to make it uneffected by the flow
  composition
- Change the content card margin rules to use
  margin-top. This is a temporary fix and will
  be changed when the footer-bottom utility is
  imported from the pattern library.