### PR TITLE
Fix missing dropdown styles

### DIFF
--- a/src/scss/bulma.scss
+++ b/src/scss/bulma.scss
@@ -5,3 +5,4 @@
 @import "~bulma/sass/form/all";
 // Icon is only used in the accordions AFAICT
 @import "~bulma/sass/elements/icon";
+@import "~bulma/sass/components/dropdown";


### PR DESCRIPTION
The Bulma dropdown styles were removed, but are
needed for the combobox fields. This adds it back.