### PR TITLE
Make the form summary collapsable

### DIFF
--- a/src/components/layout/AppContent.vue
+++ b/src/components/layout/AppContent.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="{ 'sidebar': $slots.sidebar }" :data-direction="$slots.sidebar ? 'rtl' : null">
-		<main id="content" class="stretch-single-content-card">
+		<main id="content" class="stretch-single-content-card flow">
 			<slot name="content"/>
 		</main>
 		<aside v-if="$slots.sidebar">

--- a/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormReceipt.vue
@@ -68,7 +68,7 @@
 		</template>
 	</ContentCard>
 
-	<form :action="`/donation/add?${campaignParams}`" method="post" ref="submitValuesForm" id="submit-form">
+	<form :action="`/donation/add?${campaignParams}`" method="post" ref="submitValuesForm" id="submit-form" class="visually-hidden" aria-hidden="true">
 		<SubmitValues :tracking-data="trackingData" :campaign-values="campaignValues"/>
 	</form>
 </template>

--- a/src/components/pages/donation_form/SubPages/DonationFormReceiptCompact.vue
+++ b/src/components/pages/donation_form/SubPages/DonationFormReceiptCompact.vue
@@ -28,47 +28,47 @@
 		:receipt-model="receiptModel"
 	/>
 
-	<ContentCard>
-		<template #heading v-if="paymentSummary">
-			<h2>{{ $t( 'donation_form_summary_title' ) }}</h2>
-			<DonationSummaryHeadline
-				:payment="paymentSummary"
-			/>
-		</template>
+	<ContentCard :is-collapsable="true" v-if="paymentSummary">
 		<template #content>
-			<Summary v-if="addressSummary || bankDataSummary">
-				<template #left v-if="addressSummary">
-					<AddressSummarySection
-						:address="addressSummary"
-						:countries="countries"
-						:salutations="salutations"
-					/>
-				</template>
-				<template #right v-if="bankDataSummary">
-					<PaymentSummarySection
-						:bank-data="bankDataSummary"
-					/>
-				</template>
-			</Summary>
-			<div class="switcher">
-				<FormButton
-					id="previous-btn"
-					:is-outlined="true"
-					@click="scrollToPaymentSection"
-				>
-					{{ $t( 'donation_form_section_back' ) }}
-				</FormButton>
-				<PaymentTextFormButton
-					id="submit-btn"
-					:is-loading="store.getters.isValidating"
-					:payment-type="paymentSummary?.paymentType"
-					@click="submit"
-				/>
-			</div>
+			<Accordion>
+				<AccordionItem>
+					<template #title><h2>{{ $t( 'donation_form_summary_title' ) }}</h2></template>
+					<template #content>
+						<div class="flow">
+							<DonationSummaryHeadline
+								:payment="paymentSummary"
+							/>
+							<Summary v-if="addressSummary || bankDataSummary">
+								<template #left v-if="addressSummary">
+									<AddressSummarySection
+										:address="addressSummary"
+										:countries="countries"
+										:salutations="salutations"
+									/>
+								</template>
+								<template #right v-if="bankDataSummary">
+									<PaymentSummarySection
+										:bank-data="bankDataSummary"
+									/>
+								</template>
+							</Summary>
+						</div>
+					</template>
+				</AccordionItem>
+			</Accordion>
 		</template>
 	</ContentCard>
 
-	<form :action="`/donation/add?${campaignParams}`" method="post" ref="submitValuesForm" id="submit-form">
+	<div>
+		<PaymentTextFormButton
+			id="submit-btn"
+			:is-loading="store.getters.isValidating"
+			:payment-type="paymentSummary?.paymentType"
+			@click="submit"
+		/>
+	</div>
+
+	<form :action="`/donation/add?${campaignParams}`" method="post" ref="submitValuesForm" id="submit-form" class="visually-hidden" aria-hidden="true">
 		<SubmitValues :tracking-data="trackingData" :campaign-values="campaignValues"/>
 	</form>
 </template>
@@ -85,7 +85,6 @@ import PaymentSection from '@src/components/pages/donation_form/FormSections/Pay
 import PersonalDataSection from '@src/components/pages/donation_form/FormSections/PersonalDataSectionDonationReceiptCompact.vue';
 import IbanFields from '@src/components/shared/IbanFields.vue';
 import PaymentTextFormButton from '@src/components/shared/form_elements/PaymentTextFormButton.vue';
-import FormButton from '@src/components/shared/form_elements/FormButton.vue';
 import SubmitValues from '@src/components/pages/donation_form/SubmitValues.vue';
 import ErrorSummary from '@src/components/pages/donation_form/DonationReceipt/ErrorSummary.vue';
 import { useDonationFormSubmitHandler } from '@src/components/pages/donation_form/DonationReceipt/useDonationFormSubmitHandler';
@@ -101,6 +100,8 @@ import ContentCard from '@src/components/patterns/ContentCard.vue';
 import AddressSummarySection from '@src/components/shared/AddressSummarySection.vue';
 import DonationSummaryHeadline from '@src/components/pages/donation_form/DonationSummaryHeadline.vue';
 import Summary from '@src/components/patterns/Summary.vue';
+import AccordionItem from '@src/components/patterns/AccordionItem.vue';
+import Accordion from '@src/components/patterns/Accordion.vue';
 
 defineOptions( {
 	name: 'DonationForm',
@@ -143,13 +144,6 @@ const { submit, submitValuesForm, showErrorSummary } = useDonationFormSubmitHand
 	props.validateEmailUrl,
 	receiptModel.receiptNeeded
 );
-
-const scrollToPaymentSection = () => {
-	const scrollIntoViewElement = document.getElementById( 'donation-form-heading' );
-	if ( scrollIntoViewElement ) {
-		scrollIntoViewElement.scrollIntoView( { behavior: 'auto' } );
-	}
-};
 
 onMounted( () => {
 	trackDynamicForm();

--- a/src/pattern_library/patterns/content-card/Examples.vue
+++ b/src/pattern_library/patterns/content-card/Examples.vue
@@ -25,7 +25,7 @@
 
 	<div class="content-card accordion" data-collapsable>
 		<details>
-			<summary tabindex="0">I am a details summary <span class="accordion__summary-meta"><ChevronDown/></span></summary>
+			<summary tabindex="0"><h2>I am a details summary</h2> <span class="accordion__summary-meta"><ChevronDown/></span></summary>
 			<div class="flow">
 				<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam asperiores, autem beatae consectetur corporis distinctio earum eveniet fugit illum impedit molestias
 				   obcaecati officiis optio pariatur rerum sequi similique soluta sunt.</p>

--- a/src/scss/pattern-library-compatibility/accordion.scss
+++ b/src/scss/pattern-library-compatibility/accordion.scss
@@ -1,0 +1,7 @@
+.accordion summary {
+	cursor: pointer;
+}
+
+.accordion summary h2 {
+	color: var(--color-blue-600);
+}

--- a/src/scss/pattern-library.scss
+++ b/src/scss/pattern-library.scss
@@ -11,12 +11,13 @@
 @use "../pattern_library/css/compositions/sidebar.css";
 @use "../pattern_library/css/compositions/switcher.css" as switcherBase;
 @use "../pattern_library/css/compositions/wrapper.css" as wrapperBase;
-@use "../pattern_library/css/blocks/accordion.css";
+@use "../pattern_library/css/blocks/accordion.css" as accordionBase;
 @use "../pattern_library/css/blocks/alert-box.css";
 @use "../pattern_library/css/blocks/combobox.css" as comboboxBase;
 @use "../pattern_library/css/blocks/field-container.css" as fieldContainerBase;
 @use "../pattern_library/css/blocks/text-radio.css" as textRadioBase;
 @use "../pattern_library/css/blocks/toggle.css" as toggleBase;
+@use "pattern-library-compatibility/accordion";
 @use "../pattern_library/css/blocks/tooltip.css";
 @use "../pattern_library/css/blocks/verbose-checkbox.css";
 @use "pattern-library-compatibility/combobox";


### PR DESCRIPTION
We want to hide the form summary on the new compact
donation form. To do that we put it into a collapsable
Content Card.

Ticket: https://phabricator.wikimedia.org/T405436